### PR TITLE
Tidy: Remove lazy "any" types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A long-weekend project to display rain gauge information (for one particular rai
 
 ### If I had more time
 * DRY out the types
+* Better use of "loading" elements: when the data/form is loading, and while the graph is loading
 * Add another input section to the form, one which supports one day, one week and one rolling month (calendar input for the first day, then a radio to choose between: one day; one week starting on that day; one calendar month starting on that day)
 * Add a "Custom Date Range" for people who want to specify their own range, but only want full days
 * Add automated tests

--- a/raingauge_fe/src/components/GraphWithForm.tsx
+++ b/raingauge_fe/src/components/GraphWithForm.tsx
@@ -4,8 +4,16 @@
 
 import { Graph } from "./graph/Graph";
 import { GraphForm } from "./graphForm/GraphForm";
+import { T_UseInteractiveDataOutput } from "./graphForm/util/useInteractiveData";
 
-export function GraphWithForm({ title, xCoords, yCoords, formKit } : any){
+type T_GraphWithFormProps = {
+    title : string,
+    xCoords : string[],
+    yCoords : number[],
+    formKit : T_UseInteractiveDataOutput
+}
+
+export function GraphWithForm({ title, xCoords, yCoords, formKit } : T_GraphWithFormProps){
     return (
         <div className="row mt-3">
             <div className="col-12 col-md-5 col-lg-4 col-xl-3 order-2 order-md-1">

--- a/raingauge_fe/src/components/graphForm/util/resetDateRange.tsx
+++ b/raingauge_fe/src/components/graphForm/util/resetDateRange.tsx
@@ -1,10 +1,13 @@
 import { convertStringToDate, strIsValidForDateCreation } from "@/util/dateStringHelpers";
-import { T_DateRange } from "../../../util/useAdjustableDateRange";
+import { T_AdjustableDateRangeOutput } from "../../../util/useAdjustableDateRange";
 
-type T_ResetDateRangeProps = {
+type T_ResetDateRangeProps = 
+    Pick<T_AdjustableDateRangeOutput, 
+        "updateDateRange"
+    >
+    & {
     defaultStart : string, 
-    defaultEnd : string,
-    updateDateRange : (value : T_DateRange) => void,   
+    defaultEnd : string, 
 }
 
 export function resetDateRange({defaultStart, defaultEnd, updateDateRange} : T_ResetDateRangeProps){

--- a/raingauge_fe/src/components/graphForm/util/useCustomDateRangeForm.ts
+++ b/raingauge_fe/src/components/graphForm/util/useCustomDateRangeForm.ts
@@ -6,11 +6,28 @@
 
 import { useEffect, useState } from "react";
 import { convertStringToDate, strIsValidForDateCreation } from "@/util/dateStringHelpers";
+import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
 
-type T_UseCustomDateRangeProps = {
-    updateDateRange : any, 
+type T_UseCustomDateRangeProps = 
+    Pick<T_AdjustableDateRangeOutput, 
+        "updateDateRange"
+    > & {
     defaultStart : string, 
     defaultEnd : string,
+}
+
+export type T_UseCustomDateRangeOutput = {
+    customStart : string,
+    updateStart : (datetimeStr : string) => void,
+    customEnd : string,
+    updateEnd : (datetimeStr : string) => void,
+    updateGraphData : () => void,
+    onReset : () => void,
+    errors: {
+        update : string,
+    },
+    minDate : string,
+    maxDate : string,
 }
 
 export function useCustomDateRangeForm({ updateDateRange, defaultStart, defaultEnd } : T_UseCustomDateRangeProps){

--- a/raingauge_fe/src/components/graphForm/util/useInteractiveData.tsx
+++ b/raingauge_fe/src/components/graphForm/util/useInteractiveData.tsx
@@ -2,22 +2,29 @@
     One-stop shop packaging up the hooks and resets for the multi-part form
 */
 
-import { useCustomDateRangeForm } from "./useCustomDateRangeForm";
+import { T_UseCustomDateRangeOutput, useCustomDateRangeForm } from "./useCustomDateRangeForm";
 import { resetDateRange } from "./resetDateRange";
-import { useOneMonthSelectForm, T_SelectMonthOption } from "./useOneMonthSelectForm";
+import { useOneMonthSelectForm, T_SelectMonthOption, T_UseOneMonthSelectFormOutput } from "./useOneMonthSelectForm";
+import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
 
 
 export type T_FormErrors = {
     update: string | null
 }
 
-type T_UseInteractiveDataProps = {
-    updateDateRange : any, 
-    minDate : string,
-    maxDate : string,
-    monthOptionData : T_SelectMonthOption[]
+export type T_UseInteractiveDataOutput = {
+    customDateRange : T_UseCustomDateRangeOutput,
+    oneMonthSelect : T_UseOneMonthSelectFormOutput,
+    reset : () => void,
 }
 
+type T_UseInteractiveDataProps = 
+    Pick<T_AdjustableDateRangeOutput,
+        "updateDateRange"
+        | "monthOptionData"
+        | "maxDate"
+        | "minDate"
+    >;
 export function useInteractiveData({ maxDate, minDate, monthOptionData, updateDateRange } : T_UseInteractiveDataProps){
     
     const customDateRange = useCustomDateRangeForm({

--- a/raingauge_fe/src/components/graphForm/util/useOneMonthSelectForm.tsx
+++ b/raingauge_fe/src/components/graphForm/util/useOneMonthSelectForm.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from "react";
 import { convertStringToDate } from "@/util/dateStringHelpers";
+import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
 
 export type T_SelectMonthOption = {
     display : string,
@@ -14,14 +15,24 @@ export type T_SelectMonthOption = {
     endTimestamp : string,
 }
 
-type T_UseOneMonthSelectForm = {
-    updateDateRange : any, 
-    monthOptionData : T_SelectMonthOption[]
-}
+export type T_UseOneMonthSelectFormOutput = 
+    Pick<T_AdjustableDateRangeOutput, 
+        "monthOptionData" 
+    > & {
+        monthSelect : string,
+        updateMonthSelect : (monthValue : string) => void,
+        error : string
+    };
+
+type T_UseOneMonthSelectForm = 
+    Pick<T_AdjustableDateRangeOutput, 
+        "monthOptionData" 
+        | "updateDateRange"
+    >;
 
 export function useOneMonthSelectForm({ updateDateRange, monthOptionData } : T_UseOneMonthSelectForm){
 
-    const [selectMonth, setSelectMonth] = useState<string>("");
+    const [monthSelect, setSelectMonth] = useState<string>("");
     const [monthSelectError, setMonthSelectError] = useState<string | null>(null);
 
     function updateMonthSelect(monthValue : string){
@@ -40,7 +51,7 @@ export function useOneMonthSelectForm({ updateDateRange, monthOptionData } : T_U
     }
 
     return {
-        selectMonth,
+        monthSelect,
         updateMonthSelect,
         monthOptionData,
         error: monthSelectError,

--- a/raingauge_fe/src/components/statsCards/StatsCards.tsx
+++ b/raingauge_fe/src/components/statsCards/StatsCards.tsx
@@ -1,4 +1,4 @@
-import { StatsCard } from "./StatsCard";
+import { StatsCard, T_StatsCardProps } from "./StatsCard";
 
 import { T_RainGaugeReading } from "@/util/useRainGaugeData";
 import { createStatsData } from "./createStatsData";
@@ -14,7 +14,7 @@ export function StatsCards({ data } : T_StatsCardsProps){
         <>
     { statsData !== null ?
         <div className={`container d-flex gap-3 flex-wrap`}>
-            { statsData.map((record: any, idx: number) => {
+            { statsData.map((record: T_StatsCardProps, idx: number) => {
                 return <StatsCard key={`${record.title.replaceAll(" ", "")}-${idx}`}
                     title = { record.title }
                     main = { record.main }

--- a/raingauge_fe/src/components/statsCards/createStatsData.ts
+++ b/raingauge_fe/src/components/statsCards/createStatsData.ts
@@ -3,6 +3,8 @@
 */
 
 import { formatDate } from "@/util/dateStringHelpers";
+import { T_RainGaugeReading } from "@/util/useRainGaugeData";
+import { T_StatsCardProps } from "./StatsCard";
 
 type T_StatsAccumulator = {
     total: number,
@@ -10,7 +12,9 @@ type T_StatsAccumulator = {
     max: number,
 }
 
-export function createStatsData(filteredData : any[]) : null | any[]{
+export type T_StatsDataOutput = null | T_StatsCardProps[];
+
+export function createStatsData(filteredData : T_RainGaugeReading[]) : T_StatsDataOutput{
 
     const READINGS_PER_DAY = 4 * 24;
 
@@ -18,7 +22,7 @@ export function createStatsData(filteredData : any[]) : null | any[]{
         return null;
     }
 
-    const stats = filteredData.reduce((acc : T_StatsAccumulator, curr : any) => {
+    const stats = filteredData.reduce((acc : T_StatsAccumulator, curr : T_RainGaugeReading) => {
         return {
             total: acc.total + parseFloat(curr.reading),
             max: Math.max(acc.max, parseFloat(curr.reading)),
@@ -33,20 +37,22 @@ export function createStatsData(filteredData : any[]) : null | any[]{
     }
 
     const numAtMax = filteredData.filter(record => parseFloat(record.reading) === stats.max).length;
+    const maxDate = filteredData.find(record => parseFloat(record.reading) === stats.max);
     const maxObj = {
         title: "High",
         main: formatWithMM(stats.max),
         subtitle: numAtMax === 1
-            ? formatDate(filteredData.find(record => parseFloat(record.reading) === stats.max)?.timestamp)
+            ? maxDate === undefined ? "" : formatDate(maxDate.timestamp)
             : createMinMaxSubtitle(numAtMax)
     }
 
     const numAtMin = filteredData.filter(record => parseFloat(record.reading) === stats.min).length;
+    const minDate = filteredData.find(record => parseFloat(record.reading) === stats.min);
     const minObj = {
         title: "Low",
         main: formatWithMM(stats.min),
         subtitle: numAtMin === 1
-            ? formatDate(filteredData.find(record => record.reading === stats.min)?.timestamp)
+            ? minDate === undefined ? "" : formatDate(minDate.timestamp)
             : createMinMaxSubtitle(numAtMin)
     }
 

--- a/raingauge_fe/src/util/useAdjustableDateRange.ts
+++ b/raingauge_fe/src/util/useAdjustableDateRange.ts
@@ -21,7 +21,16 @@ export type T_DateRange = {
     end : Date | null,
 }
 
-export function useAdjustableDateRange(fetchedData : T_FetchedData){
+export type T_AdjustableDateRangeOutput = {
+    data : T_RainGaugeReading[],
+    getTimeRangeGraphTitle: () => string,
+    minDate : string,
+    maxDate : string,
+    monthOptionData : T_SelectMonthOption[],
+    updateDateRange : (dateRamgeObj : T_DateRange | null) => void,
+}
+
+export function useAdjustableDateRange(fetchedData : T_FetchedData) : T_AdjustableDateRangeOutput{
     const [dateRange, setDateRange] = useState<null | T_DateRange>(null);
 
     // Updating the date range
@@ -38,10 +47,12 @@ export function useAdjustableDateRange(fetchedData : T_FetchedData){
     }
 
     function isValidDateRange(variable : any){
+        
         function isValidDateOrNull(variable : any){
             return variable === null
                 || Object.prototype.toString.call(variable) === "[object Date]";
         }
+
         return variable !== null
             && typeof variable === 'object' 
             && 'start' in variable


### PR DESCRIPTION
In some places I'd used "any" as the type while prototyping and forgot to fix it up after settlingn on an approach. Those are now replaced with actual types.