### PR TITLE
Add: New form section, refactor date range, custom colour

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A long-weekend project to display rain gauge information (for one particular rai
 ### If I had more time
 * DRY out the types
 * Better use of "loading" elements: when the data/form is loading, and while the graph is loading
-* Add another input section to the form, one which supports one day, one week and one rolling month (calendar input for the first day, then a radio to choose between: one day; one week starting on that day; one calendar month starting on that day)
 * Add a "Custom Date Range" for people who want to specify their own range, but only want full days
 * Add automated tests
 * Add cute little icons to the headings

--- a/raingauge_fe/src/app/globals.css
+++ b/raingauge_fe/src/app/globals.css
@@ -15,3 +15,26 @@ body {
   max-width: 100vw;
   overflow-x: hidden;
 }
+
+
+
+.accordion-button{
+  --c-expandedBg: #b3defa;
+  --c-expandedBgShadow: #8fd2ff;
+}
+
+.accordion-button:not(.collapsed) {
+  background-color: var(--c-expandedBg) !important;
+}
+
+.accordion-button:link, .accordion-button:visited, .accordion-button:hover, .accordion-button:active  {
+  background-color: var(--c-expandedBg) !important;
+}
+
+.accordion-button:focus {
+  z-index: 3;
+  border-color: rgb(0, 255, 234) !important;
+  outline: 0;
+  box-shadow: 0 0 0 .25rem var(--c-expandedBgShadow) !important;
+}
+

--- a/raingauge_fe/src/app/page.tsx
+++ b/raingauge_fe/src/app/page.tsx
@@ -10,20 +10,21 @@ import { useInteractiveData } from "@/components/graphForm/util/useInteractiveDa
 import { useRainGaugeData } from "@/util/useRainGaugeData";
 import { useAdjustableDateRange } from "@/util/useAdjustableDateRange";
 import { splitIntoCoords } from "@/util/splitIntoCoords";
+import { getTimeRangeGraphTitle } from "@/util/getGraphTitle";
 
 
 export default function Home() {
-
   const rainData = useRainGaugeData();
   const dataInDateRange = useAdjustableDateRange(rainData);
+
   const formKit = useInteractiveData({
     updateDateRange: dataInDateRange.updateDateRange,
     minDate: dataInDateRange.minDate,
     maxDate: dataInDateRange.maxDate,
-    monthOptionData: dataInDateRange.monthOptionData,
   });
 
   const graphCoords = splitIntoCoords(dataInDateRange.data);
+  const graphTitle = getTimeRangeGraphTitle(dataInDateRange.data);
 
   return (
       <main>
@@ -37,7 +38,7 @@ export default function Home() {
             <p>Loading...</p>
             :
             <GraphWithForm 
-              title = { dataInDateRange.getTimeRangeGraphTitle() }
+              title = { graphTitle }
               xCoords = { graphCoords.xCoords }
               yCoords = { graphCoords.yCoords }
               formKit = { formKit }
@@ -63,5 +64,3 @@ export default function Home() {
       </main>
     )
 }
-
-//text-body-secondary

--- a/raingauge_fe/src/components/GraphWithForm.tsx
+++ b/raingauge_fe/src/components/GraphWithForm.tsx
@@ -18,27 +18,17 @@ export function GraphWithForm({ title, xCoords, yCoords, formKit } : T_GraphWith
         <div className="row mt-3">
             <div className="col-12 col-md-5 col-lg-4 col-xl-3 order-2 order-md-1">
                 <GraphForm
-                    controlledEnd = { formKit.customDateRange.customEnd }
-                    updateEnd = { formKit.customDateRange.updateEnd }
-                    controlledStart = { formKit.customDateRange.customStart }
-                    updateStart = { formKit.customDateRange.updateStart } 
-                    updateGraphData = { formKit.customDateRange.updateGraphData }
-                    min = { formKit.customDateRange.minDate }
-                    max = { formKit.customDateRange.maxDate }
-                    errors = { formKit.customDateRange.errors }  
-
-                    controlledMonthSelect = { formKit.oneMonthSelect.monthSelect }
-                    updateMonthSelect = { formKit.oneMonthSelect.updateMonthSelect }
-                    monthOptionData = { formKit.oneMonthSelect.monthOptionData }
-                    
+                    customFormKit = { formKit.customDateRange }
+                    dateAndDurationKit = { formKit.dateAndDuration }
+                    oneMonthFormKit = { formKit.oneMonthSelect }
                     resetGraphData = { formKit.reset }
                 />
             </div>
             <div className="col-12 col-md-7 col-lg-8 col-xl-9 order-1 order-md-2 mb-4 mb-md-0">
                 <Graph
                     title = { title }
-                    xCoords={ xCoords }
-                    yCoords={ yCoords }
+                    xCoords ={ xCoords }
+                    yCoords ={ yCoords }
                 />
             </div>
     </div>

--- a/raingauge_fe/src/components/graphForm/GraphForm.tsx
+++ b/raingauge_fe/src/components/graphForm/GraphForm.tsx
@@ -2,25 +2,28 @@
     UI component for the full "set time range" form panel
 */
 
-import { AccordionItemWrapper } from "./AccordionItemWrapper";
-import { CustomForm, T_CustomFormProps } from "./CustomForm";
-import { OneMonthForm, T_OneMonthFormProps } from "./OneMonthForm";
+import { AccordionItemWrapper } from "./subcomponents/AccordionItemWrapper";
+import { CustomForm, T_CustomFormProps } from "./customDateRangeForm/CustomForm";
+import { OneMonthForm } from "./monthSelectForm/OneMonthForm";
+import { T_OneMonthFormProps } from "./monthSelectForm/types";
 
 import styles from './GraphForm.module.scss';
+import { DateAndDurationForm, T_DateAndDurationFormProps } from "./dateAndDurationForm/DateAndDurationForm";
 
-type T_GraphControlsProps = 
-    T_CustomFormProps
-    & T_OneMonthFormProps
-    & {
-        resetGraphData: () => void,
-    }
+type T_GraphControlsProps = {
+    customFormKit : T_CustomFormProps,
+    dateAndDurationKit : T_DateAndDurationFormProps,
+    oneMonthFormKit : T_OneMonthFormProps,
+    resetGraphData: () => void,
+}
 
 export function GraphForm({
-    controlledEnd, controlledStart, controlledMonthSelect, updateMonthSelect, monthOptionData, resetGraphData, updateEnd, updateGraphData, updateStart, errors, min, max
+    customFormKit, dateAndDurationKit, oneMonthFormKit, resetGraphData
 } : T_GraphControlsProps){
 
     const accordionID = 'id_formAccordion';
     const collapseOneMonthID = 'id_collapseOneMonth';
+    const collapseDateAndDurationID = 'id_collapseDateAndDuration';
     const collapseCustomID = 'id_collapseCustom';
     
     return (
@@ -35,11 +38,31 @@ export function GraphForm({
                     sectionID = { collapseOneMonthID }
                 >
                     <OneMonthForm
-                        controlledMonthSelect = { controlledMonthSelect }
-                        monthOptionData = { monthOptionData }
-                        updateMonthSelect = { updateMonthSelect }
+                        controlledMonthSelect = { oneMonthFormKit.controlledMonthSelect }
+                        monthOptionData = { oneMonthFormKit.monthOptionData }
+                        updateMonthSelect = { oneMonthFormKit.updateMonthSelect }
                     />
                 </AccordionItemWrapper>
+
+                <AccordionItemWrapper
+                    accordionID = { accordionID }
+                    isOpenOnLoad = { false }
+                    title = { "Date & Duration" }
+                    sectionID = { collapseDateAndDurationID }
+                >
+                    <DateAndDurationForm
+                        controlledStartDate = { dateAndDurationKit.controlledStartDate }
+                        controlledDuration = { dateAndDurationKit.controlledDuration }
+                        durationOptions = { dateAndDurationKit.durationOptions }
+                        error = { dateAndDurationKit.error }
+                        maxDate = { dateAndDurationKit.maxDate }
+                        minDate = { dateAndDurationKit.minDate }
+                        updateSelectedDuration = { dateAndDurationKit.updateSelectedDuration }
+                        updateStartDate = { dateAndDurationKit.updateStartDate }
+                        warning = { dateAndDurationKit.warning }
+                    />
+                </AccordionItemWrapper>
+
 
                 <AccordionItemWrapper
                     accordionID = { accordionID }
@@ -47,14 +70,14 @@ export function GraphForm({
                     sectionID = { collapseCustomID }
                 >
                     <CustomForm 
-                        controlledEnd = { controlledEnd } 
-                        controlledStart = { controlledStart } 
-                        updateEnd = { updateEnd } 
-                        updateGraphData = { updateGraphData } 
-                        updateStart = { updateStart } 
-                        errors = { errors } 
-                        min = { min } 
-                        max = { max } 
+                        controlledEnd = { customFormKit.controlledEnd } 
+                        controlledStart = { customFormKit.controlledStart } 
+                        updateEnd = { customFormKit.updateEnd } 
+                        updateGraphData = { customFormKit.updateGraphData } 
+                        updateStart = { customFormKit.updateStart } 
+                        errors = { customFormKit.errors } 
+                        minDate = { customFormKit.minDate } 
+                        maxDate = { customFormKit.maxDate } 
                     />
                 </AccordionItemWrapper>
 

--- a/raingauge_fe/src/components/graphForm/customDateRangeForm/CustomForm.tsx
+++ b/raingauge_fe/src/components/graphForm/customDateRangeForm/CustomForm.tsx
@@ -2,23 +2,26 @@
     UI Component for the contents of the "custom date range" portion of the form
 */
 
-import { T_FormErrors } from "./util/useInteractiveData";
+import { useId } from "react";
+import { T_FormErrors } from "../util/useInteractiveData";
 
 
 export type T_CustomFormProps = {
     controlledEnd : string,
     controlledStart : string,
+    errors : T_FormErrors,
+    maxDate : string,
+    minDate : string,
     updateEnd : (dateStr : string) => void,
     updateGraphData : () => void,
-    updateStart : (dateStr : string) => void,
-    errors : T_FormErrors,
-    min : string,
-    max : string,
+    updateStart : (dateStr : string) => void, 
 }
 
-export function CustomForm({ controlledEnd, controlledStart, updateEnd, updateGraphData, updateStart, errors, min, max } : T_CustomFormProps){
-    const idStart = "id_formInput_start";
-    const idEnd = "id_formInput_end";
+
+export function CustomForm({ controlledEnd, controlledStart, errors, minDate, maxDate, updateEnd, updateGraphData, updateStart } : T_CustomFormProps){
+    const formSectionID = useId();
+    const idStart = formSectionID + "customStart";
+    const idEnd = formSectionID + "customEnd";
 
     return (
         <>
@@ -27,11 +30,11 @@ export function CustomForm({ controlledEnd, controlledStart, updateEnd, updateGr
                 <input 
                     type="datetime-local" 
                     className="form-control" 
-                    id={idStart} 
-                    value={controlledStart} 
+                    id={ idStart } 
+                    value={ controlledStart } 
                     onChange={ (e) => updateStart(e.target.value) }
-                    min={min}
-                    max={max}
+                    min = { minDate }
+                    max = { maxDate }
                 />
             </div>
                 
@@ -43,8 +46,8 @@ export function CustomForm({ controlledEnd, controlledStart, updateEnd, updateGr
                     id={idEnd} 
                     value={controlledEnd} 
                     onChange={ (e) => updateEnd(e.target.value) }
-                    min={min}
-                    max={max}
+                    min = { minDate }
+                    max = { maxDate }
                 />
             </div>
 

--- a/raingauge_fe/src/components/graphForm/customDateRangeForm/useCustomDateRangeForm.ts
+++ b/raingauge_fe/src/components/graphForm/customDateRangeForm/useCustomDateRangeForm.ts
@@ -8,29 +8,30 @@ import { useEffect, useState } from "react";
 import { convertStringToDate, strIsValidForDateCreation } from "@/util/dateStringHelpers";
 import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
 
+
+
 type T_UseCustomDateRangeProps = 
     Pick<T_AdjustableDateRangeOutput, 
         "updateDateRange"
-    > & {
-    defaultStart : string, 
-    defaultEnd : string,
-}
+        | "minDate"
+        | "maxDate"
+    >;
 
 export type T_UseCustomDateRangeOutput = {
-    customStart : string,
-    updateStart : (datetimeStr : string) => void,
-    customEnd : string,
-    updateEnd : (datetimeStr : string) => void,
-    updateGraphData : () => void,
-    onReset : () => void,
+    controlledEnd : string,
+    controlledStart : string,
     errors: {
-        update : string,
+        update : string | null,
     },
     minDate : string,
     maxDate : string,
+    onReset : () => void,
+    updateEnd : (datetimeStr : string) => void,
+    updateStart : (datetimeStr : string) => void,
+    updateGraphData : () => void,
 }
 
-export function useCustomDateRangeForm({ updateDateRange, defaultStart, defaultEnd } : T_UseCustomDateRangeProps){
+export function useCustomDateRangeForm({ updateDateRange, minDate : defaultStart, maxDate : defaultEnd } : T_UseCustomDateRangeProps){
     
     const [customStart, setCustomStart] = useState<string>("");
     const [customEnd, setCustomEnd] = useState<string>("");
@@ -88,20 +89,16 @@ export function useCustomDateRangeForm({ updateDateRange, defaultStart, defaultE
     }
 
     return {
-        customStart,
-        updateStart,
-
-        customEnd,
-        updateEnd,
-        
-        updateGraphData,
-        onReset,
-        
+        controlledEnd: customEnd,
+        controlledStart: customStart,
         errors: {
             update: updateError,
         },
-
-        minDate: defaultStart,
         maxDate: defaultEnd,
+        minDate: defaultStart,
+        onReset,
+        updateEnd,
+        updateGraphData,
+        updateStart,
     }
 }

--- a/raingauge_fe/src/components/graphForm/dateAndDurationForm/DateAndDurationForm.tsx
+++ b/raingauge_fe/src/components/graphForm/dateAndDurationForm/DateAndDurationForm.tsx
@@ -1,0 +1,92 @@
+import { useId } from "react";
+import { T_FormErrors } from "../util/useInteractiveData";
+import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
+
+
+export type T_DateAndDurationFormProps = 
+    Pick<T_AdjustableDateRangeOutput, 
+        "maxDate" 
+        | "minDate"
+    > & {
+        controlledStartDate : string,
+        controlledDuration : string,
+        durationOptions : T_DurationOptions[],
+        error: T_FormErrors,
+        updateSelectedDuration : (optionValue : string) => void,
+        updateStartDate : (dateStr : string) => void,
+        warning: T_FormErrors,
+}
+
+export type T_DurationOptions = {
+    display : string,
+    value : string,
+}
+
+export function DateAndDurationForm({ 
+    controlledStartDate, controlledDuration, durationOptions, error, maxDate, minDate, updateSelectedDuration, updateStartDate, warning, 
+} : T_DateAndDurationFormProps){
+
+    const formSectionID = useId();
+    const idStart = formSectionID + "durationStart";
+    const idDurationRadioLabel = formSectionID + "durationRadioLabel";
+    const nameDurationRadio = formSectionID + "durationRadioName";
+    const durationOptionPrefix = formSectionID + "durationOption-";
+
+    return (
+        <>
+            <div>
+                <label htmlFor={idStart} className="form-label">Start Date</label>
+                <input 
+                    type="date" 
+                    className="form-control" 
+                    id={idStart} 
+                    value={ controlledStartDate } 
+                    onChange={ (e) => updateStartDate(e.target.value) }
+                    min={ minDate.slice(0, -9) }
+                    max={ maxDate.slice(0, -9) }
+                />
+            </div>
+            <div className="mt-4" role="radiogroup" aria-labelledby={idDurationRadioLabel} >
+                <div id={idDurationRadioLabel} className="form-label">Duration</div>
+
+                <div>
+                { durationOptions !== null && durationOptions !== undefined ?
+                    durationOptions.map(optionData => {
+                        const id = durationOptionPrefix + optionData.value;
+                        return (
+                            <div key={ optionData.value }
+                                className="form-check mt-2"
+                            >
+                                <input 
+                                    type="radio" 
+                                    className="form-check-input" 
+                                    name={ nameDurationRadio } 
+                                    id={id} 
+                                    autoComplete="off" 
+                                    value = { optionData.value }
+                                    checked={ optionData.value === controlledDuration }
+                                    onChange = { () => { updateSelectedDuration(optionData.value) } } 
+                                />
+                                <label className="form-check-label" htmlFor={id}>{ optionData.display }</label>
+                            </div>
+                        )})
+                    : null
+                }
+                </div>
+
+                <div role="region" aria-live="polite">
+                { error.update !== null && error.update !== undefined && error.update !== "" ?
+                    <p className="alert alert-danger mt-3">{error.update}</p>
+                    : null
+                }
+                { warning.form !== null && warning.form !== undefined && warning.form !== "" ?
+                    <p className="alert alert-warning mt-3">{warning.form}</p>
+                    : null
+                }
+                </div>
+
+
+            </div>
+        </>
+    )
+}

--- a/raingauge_fe/src/components/graphForm/dateAndDurationForm/useDateAndDurationForm.ts
+++ b/raingauge_fe/src/components/graphForm/dateAndDurationForm/useDateAndDurationForm.ts
@@ -1,0 +1,218 @@
+
+import { useEffect, useState } from "react";
+
+import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
+import { convertStringToDate, strIsValidForDateCreation } from "@/util/dateStringHelpers";
+
+import { T_DateAndDurationFormProps } from "./DateAndDurationForm";
+import { T_FormErrors } from "../util/useInteractiveData";
+
+
+type T_UseDateAndDurationFormProps = 
+    Pick<T_AdjustableDateRangeOutput, "maxDate" | "minDate" | "updateDateRange">;
+
+export type T_UseDateAndDurationFormOutput = 
+    Pick<T_DateAndDurationFormProps, 
+        "controlledDuration" 
+        | "controlledStartDate" 
+        | "durationOptions" 
+        | "error" 
+        | "updateSelectedDuration" 
+        | "updateStartDate"
+    > & 
+    Pick<T_AdjustableDateRangeOutput, 
+        "maxDate" 
+        | "minDate"
+    > & {
+        onReset: () => void,
+        warning : T_FormErrors
+    };
+
+
+export function useDateAndDurationForm({ 
+    minDate, maxDate, updateDateRange 
+    } : T_UseDateAndDurationFormProps
+    ) : T_UseDateAndDurationFormOutput {
+
+    const [startDateStr, setStartDateStr] = useState<string>("");
+    const [selectedDuration, setSelectedDuration] = useState<string>("toEnd");
+    const [formError, setFormError] = useState<string | null>(null);
+    const [formWarning, setFormWarning] = useState<string | null>(null);
+
+    useEffect(() => {
+        if(startDateStr === "" && minDate !== ""){
+            setStartDateStr(minDate.slice(0, -9));
+        }
+    }, [minDate]);
+
+    useEffect(() => {
+        updateGraphData();
+    }, [startDateStr, selectedDuration])
+
+    const CRITICAL_ERROR_MESSAGE = "Date and Duration has stopped working. Please use another method of selecting a date range. Sorry for the inconvenience.";
+
+    function updateStartDate(dateStr : string){
+        resetErrorAndWarning();
+        if(strIsValidForDateCreation(dateStr)){
+            setStartDateStr(dateStr);
+        }
+    }
+
+    function updateSelectedDuration(durationValue : string){
+        resetErrorAndWarning();
+        if(durationOptions.findIndex(options => options.value === durationValue) !== -1){
+            setSelectedDuration(durationValue);
+        }
+    }
+
+    function resetErrorAndWarning(){
+        setFormError(null);
+        setFormWarning(null);
+    }
+
+    function onReset(){
+        setStartDateStr(minDate.slice(0, -9));
+        setSelectedDuration("toEnd");
+        resetErrorAndWarning();
+    }
+
+    function updateGraphData(){
+        const dates = calcDates();
+        if(dates === null){
+            return;
+        }
+        updateDateRange({
+            start: dates.startDate,
+            end: dates.endDate,
+        });
+    }
+
+    function calcDates(){
+        if(!inputsAreValid()){
+            return null;
+        }
+
+        const index = durationOptions.findIndex(option => option.value === selectedDuration);
+        const durationData = durationOptions[index];
+        const startDate = convertStringToDate(`${startDateStr}T00:00:00`);
+        const endDate = durationData.calcFn();
+
+        if(checkDates(startDate, endDate)){
+            return { 
+                startDate,
+                endDate
+            };
+        } else {
+            return null;
+        }
+    }
+
+    function inputsAreValid(){
+        const index = durationOptions.findIndex(option => option.value === selectedDuration);
+        if(index === -1){
+            setFormError("Invalid duration selected. Try reloading the page.");
+            return false;
+        }
+
+        if(!strIsValidForDateCreation(startDateStr)){
+            setFormError("Invalid start date entered. Try reloading the page.");
+            return false;
+        }
+
+        return true;
+    }
+
+    function checkDates(startDate : Date, endDate : Date){
+        // Note: this returns "true" when it's ok to update the date range (regardless) and false if not.
+        // (Some of the "issues" are just... things that might be a little unexpected, so it's helpful to explain)
+
+        const minDateAsDate = new Date(minDate);
+        const maxDateAsDate = new Date(maxDate);
+
+        // This shouldn't be possible, since endDate is calculated by adding to startDate, but just in case
+        if(endDate < startDate ){
+            setFormError(CRITICAL_ERROR_MESSAGE);
+            return false;
+        }
+
+        if(startDate > maxDateAsDate || endDate < minDateAsDate){
+            setFormWarning("Dates are out of range: this could make the data do weird things.")
+            return true;   
+        }
+
+        if(endDate > maxDateAsDate){
+            setFormWarning("This duration goes past the end of the available data: displaying what exists.")
+            return true;  
+        }
+
+        return true;
+    }
+
+    
+
+    const durationOptions = [
+        { 
+            display: "One day",
+            value: "thisDay",
+            calcFn: () => addDays(1),
+        },
+        {
+            display: "One week",
+            value: "oneWeek",
+            calcFn: () => addDays(7),
+        },
+        {
+            display: "One month",
+            value: "oneCalMonth",
+            calcFn: () => calcCalMonth(1),
+        },
+        {
+            display: "Three months",
+            value: "threeCalMonths",
+            calcFn: () => calcCalMonth(3),
+        },
+        {
+            display: "End of data",
+            value: "toEnd",
+            calcFn: () => toEnd(),
+        },
+    ];
+
+    function addDays(numDaysToAdd : number){
+        // The start date is "day 1", so subtract it
+        const durationAsDateOffset = numDaysToAdd - 1;
+        let endDate = convertStringToDate(`${startDateStr}T23:59:00`);
+        endDate.setDate(endDate.getDate() + durationAsDateOffset);
+        return endDate;
+    }
+
+    function calcCalMonth(numMonthsToAdd : number){
+        const startDate = convertStringToDate(`${startDateStr}T00:00:00`);
+        const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + numMonthsToAdd, startDate.getDate() - 1, 23, 59);
+        return endDate;
+    }
+
+    function toEnd(){
+        return new Date(maxDate);
+    }
+
+
+    return {
+        controlledStartDate: startDateStr,
+        controlledDuration: selectedDuration,
+        durationOptions,
+        error: {
+            duration: formError
+        },
+        maxDate,
+        minDate,
+        onReset,
+        updateSelectedDuration,
+        updateStartDate,
+        warning: {
+            form: formWarning
+        },
+    }
+}
+
+

--- a/raingauge_fe/src/components/graphForm/monthSelectForm/OneMonthForm.tsx
+++ b/raingauge_fe/src/components/graphForm/monthSelectForm/OneMonthForm.tsx
@@ -2,13 +2,8 @@
     UI Component for the contents of the "one month" portion of the form
 */
 
-import { T_SelectMonthOption } from "./util/useOneMonthSelectForm";
+import { T_SelectMonthOption, T_OneMonthFormProps } from "./types";
 
-export type T_OneMonthFormProps = {
-    controlledMonthSelect : string,
-    monthOptionData : T_SelectMonthOption[],
-    updateMonthSelect : (value : string) => void,
-}
 
 
 export function OneMonthForm({ controlledMonthSelect, monthOptionData, updateMonthSelect } : T_OneMonthFormProps){
@@ -23,6 +18,9 @@ export function OneMonthForm({ controlledMonthSelect, monthOptionData, updateMon
                         value = { controlledMonthSelect }
                         onChange = { (e) => updateMonthSelect(e.target.value) }
                     >
+                        <option value="disabledDefault" disabled>
+                            Select a month
+                        </option>
                         { monthOptionData.map((optionData : T_SelectMonthOption) => {
                             return <option key={optionData.value}
                                         value={optionData.value}

--- a/raingauge_fe/src/components/graphForm/monthSelectForm/getMonthSelectOptions.ts
+++ b/raingauge_fe/src/components/graphForm/monthSelectForm/getMonthSelectOptions.ts
@@ -1,0 +1,49 @@
+import { formatTwoDigits } from "@/util/dateStringHelpers";
+import { T_SelectMonthOption } from "./types";
+
+import { T_TimeRangeOfData } from "@/util/useAdjustableDateRange";
+
+// Support for the "select one month" select: creates a list of months, with 
+// human-readable names, computer-readable values, and how this translates to timestamps
+export function getMonthOptionData(startAndEnd : T_TimeRangeOfData) : T_SelectMonthOption[] {
+
+    if(startAndEnd.start === "" || startAndEnd.end === ""){
+        return [];
+    }
+    const startDate = new Date(startAndEnd.start);
+    const endDate = new Date(startAndEnd.end);
+
+    let monthOptionData = [];
+    for(let year = startDate.getFullYear(); year < endDate.getFullYear() + 1; year++){
+
+        // Dynamic start and end numbers for the month loop to handle incomplete years at the start and end of the data
+        const startMonth = year === startDate.getFullYear()
+            ? startDate.getMonth()
+            : 0;
+        const endMonth = year === endDate.getFullYear()
+            ? endDate.getMonth()
+            : 12;
+
+        for(let month = startMonth; month < endMonth; month++){
+            const newMonthData = formatAsMonthOptionData(month, year);
+            monthOptionData.push(newMonthData);
+        }
+    }
+
+    return monthOptionData;
+}
+
+function formatAsMonthOptionData(month : number, year : number){
+    const firstDayOfMonth = new Date(year, month, 1);
+    // To save relearning this if it doesn't come up again for a while:
+    // [Date] considers "0th of $MONTH" to be "the day before the 1st of $MONTH" aka "last day of ($MONTH - 1)",
+    const lastDayOfMonth = new Date(year, month + 1, 0);
+
+    const newMonthData = {
+        display: `${firstDayOfMonth.toLocaleString('default', { month: 'long' })} ${firstDayOfMonth.getFullYear()}`,
+        value: `${firstDayOfMonth.getFullYear()}-${formatTwoDigits(firstDayOfMonth.getMonth()+1)}`,
+        startTimestamp: `${firstDayOfMonth.getFullYear()}-${formatTwoDigits(firstDayOfMonth.getMonth() + 1)}-01T00:00`,
+        endTimestamp: `${lastDayOfMonth.getFullYear()}-${formatTwoDigits(lastDayOfMonth.getMonth() + 1)}-${lastDayOfMonth.getDate()}T23:59`
+    }
+    return newMonthData;
+}

--- a/raingauge_fe/src/components/graphForm/monthSelectForm/types.ts
+++ b/raingauge_fe/src/components/graphForm/monthSelectForm/types.ts
@@ -1,0 +1,29 @@
+import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
+
+// Package to support <select> for months
+export type T_SelectMonthOption = {
+    display : string,
+    value : string,
+    startTimestamp : string,
+    endTimestamp : string,
+}
+
+export type T_UseOneMonthSelectFormOutput = 
+    T_OneMonthFormProps
+    & {
+        error : string | null
+    };
+
+export type T_OneMonthFormProps = {
+    controlledMonthSelect : string,
+    monthOptionData : T_SelectMonthOption[],
+    updateMonthSelect : (value : string) => void,
+}
+
+export type T_UseOneMonthSelectFormProps = 
+    Pick<T_AdjustableDateRangeOutput, 
+        "minDate"
+        | "maxDate"
+        | "updateDateRange"
+    >;
+

--- a/raingauge_fe/src/components/graphForm/monthSelectForm/useOneMonthSelectForm.tsx
+++ b/raingauge_fe/src/components/graphForm/monthSelectForm/useOneMonthSelectForm.tsx
@@ -5,35 +5,20 @@
 */
 
 import { useState } from "react";
+
 import { convertStringToDate } from "@/util/dateStringHelpers";
-import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
 
-export type T_SelectMonthOption = {
-    display : string,
-    value : string,
-    startTimestamp : string,
-    endTimestamp : string,
-}
+import { getMonthOptionData } from "./getMonthSelectOptions";
+import { T_UseOneMonthSelectFormProps } from "./types";
 
-export type T_UseOneMonthSelectFormOutput = 
-    Pick<T_AdjustableDateRangeOutput, 
-        "monthOptionData" 
-    > & {
-        monthSelect : string,
-        updateMonthSelect : (monthValue : string) => void,
-        error : string
-    };
+export function useOneMonthSelectForm({ maxDate, minDate, updateDateRange } : T_UseOneMonthSelectFormProps){
 
-type T_UseOneMonthSelectForm = 
-    Pick<T_AdjustableDateRangeOutput, 
-        "monthOptionData" 
-        | "updateDateRange"
-    >;
+    const valueForDisabledDefault = "disabledDefault";
 
-export function useOneMonthSelectForm({ updateDateRange, monthOptionData } : T_UseOneMonthSelectForm){
-
-    const [monthSelect, setSelectMonth] = useState<string>("");
+    const [monthSelect, setSelectMonth] = useState<string>(valueForDisabledDefault);
     const [monthSelectError, setMonthSelectError] = useState<string | null>(null);
+
+    const monthOptionData = getMonthOptionData({ start: minDate, end: maxDate });
 
     function updateMonthSelect(monthValue : string){
         const chosenMonth = monthOptionData.find(data => monthValue === data.value );
@@ -50,10 +35,15 @@ export function useOneMonthSelectForm({ updateDateRange, monthOptionData } : T_U
         }
     }
 
+    function onReset(){
+        setSelectMonth(valueForDisabledDefault);
+    }
+
     return {
-        monthSelect,
-        updateMonthSelect,
-        monthOptionData,
+        controlledMonthSelect: monthSelect,
         error: monthSelectError,
+        monthOptionData,
+        onReset,
+        updateMonthSelect,
     }
 }

--- a/raingauge_fe/src/components/graphForm/subcomponents/AccordionItemWrapper.tsx
+++ b/raingauge_fe/src/components/graphForm/subcomponents/AccordionItemWrapper.tsx
@@ -2,7 +2,8 @@
     Wrapper implementing Bootstrap's accordion item
 */
 
-import { ReactNode } from "react"
+import { ReactNode } from "react";
+import styles from './AccordionItemWrapper.module.scss';
 
 type T_AccordionItemWrapper = {
     accordionID : string,

--- a/raingauge_fe/src/components/graphForm/util/resetDateRange.tsx
+++ b/raingauge_fe/src/components/graphForm/util/resetDateRange.tsx
@@ -1,13 +1,10 @@
 import { convertStringToDate, strIsValidForDateCreation } from "@/util/dateStringHelpers";
-import { T_AdjustableDateRangeOutput } from "../../../util/useAdjustableDateRange";
+import { T_UpdateDateRange } from "../../../util/useAdjustableDateRange";
 
-type T_ResetDateRangeProps = 
-    Pick<T_AdjustableDateRangeOutput, 
-        "updateDateRange"
-    >
-    & {
+type T_ResetDateRangeProps = {
     defaultStart : string, 
     defaultEnd : string, 
+    updateDateRange : T_UpdateDateRange,
 }
 
 export function resetDateRange({defaultStart, defaultEnd, updateDateRange} : T_ResetDateRangeProps){

--- a/raingauge_fe/src/components/graphForm/util/useInteractiveData.tsx
+++ b/raingauge_fe/src/components/graphForm/util/useInteractiveData.tsx
@@ -2,18 +2,21 @@
     One-stop shop packaging up the hooks and resets for the multi-part form
 */
 
-import { T_UseCustomDateRangeOutput, useCustomDateRangeForm } from "./useCustomDateRangeForm";
+import { T_UseCustomDateRangeOutput, useCustomDateRangeForm } from "../customDateRangeForm/useCustomDateRangeForm";
 import { resetDateRange } from "./resetDateRange";
-import { useOneMonthSelectForm, T_SelectMonthOption, T_UseOneMonthSelectFormOutput } from "./useOneMonthSelectForm";
+import { useOneMonthSelectForm } from "../monthSelectForm/useOneMonthSelectForm";
 import { T_AdjustableDateRangeOutput } from "@/util/useAdjustableDateRange";
+import { T_UseOneMonthSelectFormOutput } from "../monthSelectForm/types";
+import { T_UseDateAndDurationFormOutput, useDateAndDurationForm } from "../dateAndDurationForm/useDateAndDurationForm";
 
 
 export type T_FormErrors = {
-    update: string | null
+    [key: string]: string | null
 }
 
 export type T_UseInteractiveDataOutput = {
     customDateRange : T_UseCustomDateRangeOutput,
+    dateAndDuration : T_UseDateAndDurationFormOutput,
     oneMonthSelect : T_UseOneMonthSelectFormOutput,
     reset : () => void,
 }
@@ -21,25 +24,34 @@ export type T_UseInteractiveDataOutput = {
 type T_UseInteractiveDataProps = 
     Pick<T_AdjustableDateRangeOutput,
         "updateDateRange"
-        | "monthOptionData"
         | "maxDate"
         | "minDate"
     >;
-export function useInteractiveData({ maxDate, minDate, monthOptionData, updateDateRange } : T_UseInteractiveDataProps){
+
+export function useInteractiveData({ maxDate, minDate, updateDateRange } : T_UseInteractiveDataProps){
     
     const customDateRange = useCustomDateRangeForm({
-        defaultStart: minDate,
-        defaultEnd: maxDate,
+        minDate,
+        maxDate,
         updateDateRange,
     });
 
     const oneMonthSelect = useOneMonthSelectForm({
-        updateDateRange, 
-        monthOptionData
+        minDate,
+        maxDate,
+        updateDateRange
+    });
+
+    const dateAndDuration = useDateAndDurationForm({
+        minDate,
+        maxDate,
+        updateDateRange
     });
 
     function combinedReset(){
         customDateRange.onReset();
+        dateAndDuration.onReset();
+        oneMonthSelect.onReset();
 
         resetDateRange({
             defaultStart: minDate,
@@ -50,6 +62,7 @@ export function useInteractiveData({ maxDate, minDate, monthOptionData, updateDa
 
     return {
         customDateRange,
+        dateAndDuration,
         oneMonthSelect,
         reset: combinedReset
     }

--- a/raingauge_fe/src/util/getGraphTitle.ts
+++ b/raingauge_fe/src/util/getGraphTitle.ts
@@ -1,0 +1,20 @@
+/* 
+    Generate a title for the graph, showing the timestamps of the first and last data point in the selected time range
+    (e.g. Suppose the user picked an end time of "23:59". Readings are at 15 min intervals, so the last data points 
+    would be at 23:45, therefore "23:45" is displayed)
+*/
+
+import { formatDate } from "./dateStringHelpers";
+import { T_RainGaugeReading } from "./useRainGaugeData";
+
+export function getTimeRangeGraphTitle(selectedData : T_RainGaugeReading[]){
+    selectedData = selectedData === null || selectedData === undefined || !Array.isArray(selectedData) || selectedData.length === 0
+        ? [{ reading: '0', timestamp: "01/01/1900T00:00" }]
+        : selectedData;
+
+    const startStr = formatDate(selectedData[0].timestamp);
+    const endStr = formatDate(selectedData[selectedData.length - 1].timestamp);
+
+    // Plotly has no support for title word wrapping and requires users to pass in their own "<br>" tags
+    return `Data from ${startStr}<br>to ${endStr}`;
+}

--- a/raingauge_fe/src/util/sortRainGaugeData.ts
+++ b/raingauge_fe/src/util/sortRainGaugeData.ts
@@ -1,0 +1,9 @@
+import { T_RainGaugeReading } from "./useRainGaugeData";
+
+export function sortInDateOrder(data : T_RainGaugeReading[]){
+    return data.toSorted((a : T_RainGaugeReading, b : T_RainGaugeReading) => {
+        const aDate = new Date(a.timestamp).valueOf();
+        const bDate = new Date(b.timestamp).valueOf();
+        return aDate - bDate;
+    })
+}

--- a/raingauge_fe/src/util/useRainGaugeData.ts
+++ b/raingauge_fe/src/util/useRainGaugeData.ts
@@ -3,6 +3,7 @@
 */
 
 import useSWR from "swr";
+import { sortInDateOrder } from "./sortRainGaugeData";
 
 export type T_RainGaugeReading = {
     timestamp : string,


### PR DESCRIPTION
* Refactored the date range hook so it's only concerned with matters relating to the date range. Functions using that info to make things - graph title, month select options - moved elsewhere

* Added a "Date & Duration" section to the form, allowing users to filter the date range by specifying a start date and then selecting a duration from a radio

* Overrode the Bootstrap formatting on the active accordion section because the default didn't look great with my panel background colour (different hues of blue)