### PR TITLE
Feature: Data limiting

### DIFF
--- a/raingauge_be/manage.py
+++ b/raingauge_be/manage.py
@@ -20,3 +20,5 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+

--- a/raingauge_be/rainGauge/subtotals.py
+++ b/raingauge_be/rainGauge/subtotals.py
@@ -1,0 +1,158 @@
+## Premise: sending users ~28k records is unnecessary. Although we don't want to couple
+## the front and backend too closely, it's worth considering that presently the graph
+## displays at a maximum width of 760px, so ~28k records = ~37 datapoints crammed into
+## each pixel = proooobably overkill
+def get_subtotal_config():
+    NUM_RECORDS_PER_HOUR = 4
+    ASCENDING_SUPPORTED_SIZES_IN_HOURS = [
+        1 / NUM_RECORDS_PER_HOUR, 
+        1, 3, 6, 12, 24
+    ]
+
+    return {
+        'API_RESPONSE_RECORD_LIMIT': 1000,
+        'NUM_RECORDS_PER_HOUR': NUM_RECORDS_PER_HOUR,
+        'FALLBACK_SIZE_IN_HOURS': ASCENDING_SUPPORTED_SIZES_IN_HOURS[len(ASCENDING_SUPPORTED_SIZES_IN_HOURS) - 1],
+        'ASC_SIZES_IN_HOURS': ASCENDING_SUPPORTED_SIZES_IN_HOURS
+    }
+
+
+def get_subtotals(query_set):
+    """
+        Converts a query set of RainGaugeReadings into JSON-able subtotal objects.
+        Output:
+        {
+            'firstTimestamp': Date,
+            'lastTimestamp': Date,
+            'total': Float,
+            'numReadings': Integer,
+            'max': {
+                'reading': Float,
+                'count': Integer,
+                'timestamp': Date,
+            },
+            'min': {
+                'reading': Float,
+                'count': Integer,
+                'timestamp': Date,
+        }
+    """
+
+    size_in_hours = get_size_in_hours(query_set)
+    sorted = query_set.order_by('timestamp')
+    config = get_subtotal_config()
+
+    subtotals = []
+    working_subtotal = None
+
+    for record in sorted:
+        if working_subtotal == None:
+            working_subtotal = create_new_subtotal_from(record)
+        else:
+            working_subtotal = update_subtotal(working_subtotal, record)
+
+        # If this reading is at the end of the subtotal block, store the now-finished working subtotal and reset
+        if (    size_in_hours >= 1    and is_timestamp_end_of_full_hour_block(record, size_in_hours)
+            or  size_in_hours == 1 / config['NUM_RECORDS_PER_HOUR']
+            ) :
+                subtotals.append(working_subtotal)
+                working_subtotal = None
+
+    # If the data ended partway through a subtotal time block, there could be an incomplete block: store that too
+    if not working_subtotal == None:
+        subtotals.append(working_subtotal)
+
+    return subtotals
+
+
+def get_size_in_hours(filtered_query_set):
+    """
+    For the specified data, get the highest resolution of data that's supported and within the 
+    chosen response size limit for the API
+    """
+    config = get_subtotal_config()
+    data_size = filtered_query_set.count()
+
+    for this_size in config['ASC_SIZES_IN_HOURS']:
+        num_subtotals = data_size / config['NUM_RECORDS_PER_HOUR'] / this_size
+
+        if num_subtotals <= config['API_RESPONSE_RECORD_LIMIT']:
+            return this_size
+        
+    return config['FALLBACK_SIZE_IN_HOURS']
+
+
+def is_timestamp_end_of_full_hour_block(reading, numHours):
+    # The HH:00 reading covers the rain that fell between HH:45 and HH:00, so it should be the 
+    # last subtotal in each hour, rather than the first
+    intNumHours = int(numHours)
+    return reading.timestamp.hour % intNumHours == 0 and reading.timestamp.minute == 00
+
+
+def create_new_subtotal_from(record):
+    return {
+        'firstTimestamp': record.timestamp,
+        'lastTimestamp': record.timestamp,
+        'total': record.reading,
+        'numReadings': 1,
+        'max': {
+            'reading': record.reading,
+            'count': 1,
+            'timestamp': record.timestamp,
+        },
+        'min': {
+            'reading':  record.reading,
+            'count': 1,
+            'timestamp': record.timestamp,
+        },
+    }
+
+
+def update_subtotal(subtotal, record):
+    newMax = get_new_min_max_object(subtotal['max'], record, record.reading > subtotal['max']['reading'])
+    newMin = get_new_min_max_object(subtotal['min'], record, record.reading < subtotal['min']['reading'])
+
+    return {
+        'firstTimestamp': subtotal['firstTimestamp'],
+        'lastTimestamp': record.timestamp,
+        'total' : subtotal['total'] + record.reading,
+        'numReadings': subtotal['numReadings'] + 1,
+        'max': newMax,
+        'min': newMin,
+    }
+
+
+def get_new_min_max_object(subtotalMinOrMaxObj, record, want_replace):
+    # GOAL:
+    # Min and Max should both behave in the following way:
+
+    #   If the new record exceeds the previous min/max:
+    #       Record its reading as the new min/max reading
+    #       Restart the count at "1"
+    #       Record its timestamp
+
+    #   If the new record equals the previous min/max:
+    #       +1 to the count
+    #       Remove the now-meaningless timestamp, since we have more than
+
+
+    if want_replace:
+        count = 1
+        reading = record.reading
+        timestamp = record.timestamp
+
+    elif record.reading == subtotalMinOrMaxObj['reading']:
+        count = subtotalMinOrMaxObj['count'] + 1
+        reading = record.reading
+        timestamp = None
+
+    else:
+        count = subtotalMinOrMaxObj['count']
+        reading = subtotalMinOrMaxObj['reading']
+        timestamp = subtotalMinOrMaxObj['timestamp']
+
+    return {
+        'count': count,
+        'reading': reading,
+        'timestamp': timestamp
+    }

--- a/raingauge_be/rainGauge/util.py
+++ b/raingauge_be/rainGauge/util.py
@@ -1,0 +1,15 @@
+import datetime 
+
+
+def get_date_from_get_arg(arg_str):
+    """
+    Converts a date from a GET query into a date object.
+    If this doesn't work, it will use the timestamp from the record instead
+    """
+
+    try:
+        date_obj = datetime.datetime.strptime(arg_str, '%Y-%m-%dT%H:%M')
+        return date_obj
+    
+    except:
+        return None

--- a/raingauge_be/rainGauge/views.py
+++ b/raingauge_be/rainGauge/views.py
@@ -1,15 +1,37 @@
 from django.http import JsonResponse
 from rainGauge.models import RainGaugeReading
 
+from rainGauge.subtotals import get_subtotals, get_subtotal_config
+from rainGauge.util import get_date_from_get_arg
+
 def api(request):
     if request.method == 'GET':
-        readings = RainGaugeReading.objects.all()
-        readingsSerialised = []
-        for r in readings:
-            readingsSerialised.append(r.serialise())
+
+        query_set = RainGaugeReading.objects.all()
+        sorted = query_set.order_by('timestamp')
+        minDate = sorted[0].timestamp
+        maxDate = sorted[len(sorted) - 1].timestamp
+
+        start_arg = request.GET.get('start', None)
+        end_arg = request.GET.get('end', None)
+        start = get_date_from_get_arg(start_arg)
+        end = get_date_from_get_arg(end_arg)
+
+        if start == None or end_arg == None:
+            start = minDate if start == None else start
+            end = sorted[len(sorted) - 1].timestamp if end == None else end
+        
+        filtered = query_set.filter(timestamp__gte=start, timestamp__lte=end)
+        subtotals = get_subtotals(filtered)
+        config = get_subtotal_config()
 
         return JsonResponse({
-           'data': readingsSerialised
+           'subtotals': subtotals,
+           'maxRecordsPerRequest': config['API_RESPONSE_RECORD_LIMIT'],
+           'recordsPerHour': config['NUM_RECORDS_PER_HOUR'],
+           'subtotalSizesInHours': config['ASC_SIZES_IN_HOURS'],
+           'minDate': minDate,
+           'maxDate': maxDate,
         }, status = 200)
 
     return JsonResponse({}, 405)

--- a/raingauge_fe/src/app/page.tsx
+++ b/raingauge_fe/src/app/page.tsx
@@ -9,7 +9,7 @@ import { useInteractiveData } from "@/components/graphForm/util/useInteractiveDa
 
 import { useRainGaugeData } from "@/util/useRainGaugeData";
 import { useAdjustableDateRange } from "@/util/useAdjustableDateRange";
-import { splitIntoCoords } from "@/util/splitIntoCoords";
+import { splitSubtotalIntoCoords } from "@/util/splitIntoCoords";
 import { getTimeRangeGraphTitle } from "@/util/getGraphTitle";
 
 
@@ -23,8 +23,8 @@ export default function Home() {
     maxDate: dataInDateRange.maxDate,
   });
 
-  const graphCoords = splitIntoCoords(dataInDateRange.data);
-  const graphTitle = getTimeRangeGraphTitle(dataInDateRange.data);
+  const graphCoords = splitSubtotalIntoCoords(dataInDateRange.subtotals);
+  const graphTitle = getTimeRangeGraphTitle(dataInDateRange?.subtotals[0]?.firstTimestamp, dataInDateRange?.subtotals[dataInDateRange.subtotals.length - 1]?.lastTimestamp);
 
   return (
       <main>
@@ -34,27 +34,21 @@ export default function Home() {
           />
 
           <div className="row mt-5"> 
-          { rainData.isLoading ?
-            <p>Loading...</p>
-            :
             <GraphWithForm 
               title = { graphTitle }
               xCoords = { graphCoords.xCoords }
               yCoords = { graphCoords.yCoords }
               formKit = { formKit }
             />
-          }
           </div>
 
-          {dataInDateRange.data.length !== 0 ?
           <div className="row mt-5">
             <StatsCards 
-              data = { dataInDateRange.data }
+              data = { dataInDateRange.subtotals }
+              numRecordsPerHour = { rainData.data === undefined ? 0 : rainData.data.recordsPerHour }
             />
           </div>
-          : null
-          }
-
+  
           <div className="row mt-5">
             <MapPanel
               data = { rainData }

--- a/raingauge_fe/src/components/graph/Graph.tsx
+++ b/raingauge_fe/src/components/graph/Graph.tsx
@@ -17,7 +17,7 @@ type T_GraphProps = {
 export function Graph({ xCoords, yCoords, title } : T_GraphProps){
     return <div id="tester" className={`container rounded ${styles.graphContainer}`}>
         <Plot
-            //@ts-ignore (TypeScript is fussing, but since this is a third-party thing and it works, TS can shush)
+            //@ts-ignore (TypeScript is fussing, but since this is a third-party thing and it's working, TS can shush)
             data={[
                     {
                         x: xCoords ?? [],
@@ -28,10 +28,9 @@ export function Graph({ xCoords, yCoords, title } : T_GraphProps){
                     },
 
             ]}
-            layout={ { title } } 
+            layout={ { title, margin: { l: 20, r: 20 }, } } 
             useResizeHandler={true}
             style={{width: "100%", height: "100%"}}
-            margin={{t: 0, b: 0, l: 0, r: 0}}
         />
     </div>
 }

--- a/raingauge_fe/src/components/graphForm/dateAndDurationForm/useDateAndDurationForm.ts
+++ b/raingauge_fe/src/components/graphForm/dateAndDurationForm/useDateAndDurationForm.ts
@@ -94,7 +94,7 @@ export function useDateAndDurationForm({
 
         const index = durationOptions.findIndex(option => option.value === selectedDuration);
         const durationData = durationOptions[index];
-        const startDate = convertStringToDate(`${startDateStr}T00:00:00`);
+        const startDate = convertStringToDate(`${startDateStr}T00:01:00`);
         const endDate = durationData.calcFn();
 
         if(checkDates(startDate, endDate)){
@@ -123,8 +123,10 @@ export function useDateAndDurationForm({
     }
 
     function checkDates(startDate : Date, endDate : Date){
-        // Note: this returns "true" when it's ok to update the date range (regardless) and false if not.
-        // (Some of the "issues" are just... things that might be a little unexpected, so it's helpful to explain)
+        /*
+            This check looks out for issues of varying degrees of severity.
+            It returns "true" when it's ok to update the date range and false if not.
+        */
 
         const minDateAsDate = new Date(minDate);
         const maxDateAsDate = new Date(maxDate);
@@ -179,16 +181,18 @@ export function useDateAndDurationForm({
     ];
 
     function addDays(numDaysToAdd : number){
-        // The start date is "day 1", so subtract it
-        const durationAsDateOffset = numDaysToAdd - 1;
-        let endDate = convertStringToDate(`${startDateStr}T23:59:00`);
+        const offsetToRemoveDoubleCount = -1;
+        const offsetToIncludeMidnight = 1;
+        const durationAsDateOffset = numDaysToAdd + offsetToRemoveDoubleCount + offsetToIncludeMidnight;
+
+        let endDate = convertStringToDate(`${startDateStr}T00:00:00`);
         endDate.setDate(endDate.getDate() + durationAsDateOffset);
         return endDate;
     }
 
     function calcCalMonth(numMonthsToAdd : number){
-        const startDate = convertStringToDate(`${startDateStr}T00:00:00`);
-        const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + numMonthsToAdd, startDate.getDate() - 1, 23, 59);
+        const startDate = convertStringToDate(`${startDateStr}T00:01:00`);
+        const endDate = new Date(startDate.getFullYear(), startDate.getMonth() + numMonthsToAdd, startDate.getDate(), 0, 0);
         return endDate;
     }
 

--- a/raingauge_fe/src/components/graphForm/monthSelectForm/getMonthSelectOptions.ts
+++ b/raingauge_fe/src/components/graphForm/monthSelectForm/getMonthSelectOptions.ts
@@ -34,16 +34,24 @@ export function getMonthOptionData(startAndEnd : T_TimeRangeOfData) : T_SelectMo
 }
 
 function formatAsMonthOptionData(month : number, year : number){
-    const firstDayOfMonth = new Date(year, month, 1);
-    // To save relearning this if it doesn't come up again for a while:
-    // [Date] considers "0th of $MONTH" to be "the day before the 1st of $MONTH" aka "last day of ($MONTH - 1)",
-    const lastDayOfMonth = new Date(year, month + 1, 0);
+    /*
+        Each timestamp reflects when the reading was taken and therefore represents the rain that fell in the 
+        preceeding 15 minute period. This means all __:00 readings should be considered the last reading 
+        of the previous hour (and, by extention, the last of the week, day, month, year, etc.).
 
+        > startTimestamp uses a time of "00:01" to avoid the 00:00 last-reading that belongs to the previous month
+        > endTimestamp is set to the first day of the next month and uses "00:00" so as to capture its last-reading
+    */
+
+    const firstDayOfMonth = new Date(year, month, 1);
+    const firstDayNextMonth = new Date(year, month + 1, 1);
+    
     const newMonthData = {
         display: `${firstDayOfMonth.toLocaleString('default', { month: 'long' })} ${firstDayOfMonth.getFullYear()}`,
-        value: `${firstDayOfMonth.getFullYear()}-${formatTwoDigits(firstDayOfMonth.getMonth()+1)}`,
-        startTimestamp: `${firstDayOfMonth.getFullYear()}-${formatTwoDigits(firstDayOfMonth.getMonth() + 1)}-01T00:00`,
-        endTimestamp: `${lastDayOfMonth.getFullYear()}-${formatTwoDigits(lastDayOfMonth.getMonth() + 1)}-${lastDayOfMonth.getDate()}T23:59`
+        value: `${firstDayOfMonth.getFullYear()}-${formatTwoDigits(firstDayOfMonth.getMonth() + 1)}`,
+        startTimestamp: `${firstDayOfMonth.getFullYear()}-${formatTwoDigits(firstDayOfMonth.getMonth() + 1)}-01T00:01`,
+        endTimestamp: `${firstDayNextMonth.getFullYear()}-${formatTwoDigits(firstDayNextMonth.getMonth() + 1)}-01T00:00`
     }
+
     return newMonthData;
 }

--- a/raingauge_fe/src/components/statsCards/StatsCards.tsx
+++ b/raingauge_fe/src/components/statsCards/StatsCards.tsx
@@ -1,15 +1,17 @@
 import { StatsCard, T_StatsCardProps } from "./StatsCard";
 
-import { T_RainGaugeReading } from "@/util/useRainGaugeData";
+import { T_RainGaugeSubtotal } from "@/util/useRainGaugeData";
 import { createStatsData } from "./createStatsData";
 
 
 type T_StatsCardsProps = {
-    data : T_RainGaugeReading[],
+    data : T_RainGaugeSubtotal[],
+    numRecordsPerHour : number,
 }
 
-export function StatsCards({ data } : T_StatsCardsProps){
-    const statsData = createStatsData(data);
+export function StatsCards({ data, numRecordsPerHour } : T_StatsCardsProps){
+    const statsData = createStatsData(data, numRecordsPerHour);
+
     return (
         <>
     { statsData !== null ?

--- a/raingauge_fe/src/components/statsCards/createStatsData.ts
+++ b/raingauge_fe/src/components/statsCards/createStatsData.ts
@@ -3,72 +3,128 @@
 */
 
 import { formatDate } from "@/util/dateStringHelpers";
-import { T_RainGaugeReading } from "@/util/useRainGaugeData";
+import { T_RainGaugeSubtotal, T_RainGaugeSubtotalMinMax } from "@/util/useRainGaugeData";
 import { T_StatsCardProps } from "./StatsCard";
 
-type T_StatsAccumulator = {
-    total: number,
-    min: number,
-    max: number,
+export type T_StatsDataOutput = T_StatsCardProps[];
+
+type T_RainGaugeSubtotalMinMaxProcessed = {
+    count : number,
+    timestamp : Date | null,
+    reading: number,
 }
 
-export type T_StatsDataOutput = null | T_StatsCardProps[];
 
-export function createStatsData(filteredData : T_RainGaugeReading[]) : T_StatsDataOutput{
+type T_StatsAccumulator = {
+    total : number,
+    min : T_RainGaugeSubtotalMinMaxProcessed,
+    max : T_RainGaugeSubtotalMinMaxProcessed,
+    numReadings : number,
+}
 
-    const READINGS_PER_DAY = 4 * 24;
 
-    if(filteredData.length === 0){
-        return null;
-    }
+export function createStatsData(filteredData : T_RainGaugeSubtotal[], numReadingsPerHour : number) : T_StatsDataOutput{
+    const FALLBACK_STATS = { 
+        total: 0, 
+        max: { 
+            reading: 0, 
+            count: 0, 
+            timestamp: null 
+        }, 
+        min: { 
+            reading: 0, 
+            count: 0, 
+            timestamp: null 
+        }, 
+        numReadings: 0 
+    };
 
-    const stats = filteredData.reduce((acc : T_StatsAccumulator, curr : T_RainGaugeReading) => {
+    const stats = filteredData.length === 0
+        ? FALLBACK_STATS
+        : calculateStats(filteredData);
+
+    return formatStats(stats, numReadingsPerHour);
+}
+
+
+function calculateStats(filteredData : T_RainGaugeSubtotal[]){
+    return filteredData.reduce((acc : T_StatsAccumulator, curr : T_RainGaugeSubtotal) => {
+        const newMax = getNewMinMaxObject(acc.max, curr.max, parseFloat(curr.max.reading) > acc.max.reading);
+        const newMin = getNewMinMaxObject(acc.min, curr.min, parseFloat(curr.min.reading) < acc.min.reading);
+
         return {
-            total: acc.total + parseFloat(curr.reading),
-            max: Math.max(acc.max, parseFloat(curr.reading)),
-            min: Math.min(acc.min, parseFloat(curr.reading)),
+            total: acc.total + parseFloat(curr.total),
+            max: newMax,
+            min: newMin,
+            numReadings: acc.numReadings + parseFloat(curr.numReadings),
         }
-    }, { total: 0, min: Infinity, max: -Infinity });
+    }, { total: 0, numReadings: 0, min: { reading: Infinity, count: 0, timestamp: null }, max: { reading: -Infinity, count: 0, timestamp: null } });
+
+
+    function getNewMinMaxObject(accMinMax : T_RainGaugeSubtotalMinMaxProcessed, currMinMax : T_RainGaugeSubtotalMinMax, wantReplace : boolean){
+        let count, reading, timestamp;
+
+        if(wantReplace){
+            count = 1;
+            reading = parseFloat(currMinMax.reading);
+            timestamp = new Date(currMinMax.timestamp);
+        }
+        else if(accMinMax.reading === parseFloat(currMinMax.reading)){
+            count = accMinMax.count + parseFloat(currMinMax.count)
+            reading = accMinMax.reading;
+            timestamp = null;
+        }
+        else {
+            count = accMinMax.count;
+            reading = accMinMax.reading;
+            timestamp = accMinMax.timestamp
+        }
+
+        return { count, reading, timestamp }
+    }
+}
+
+
+function formatStats(stats : T_StatsAccumulator, numReadingsPerHour : number){
+    const READINGS_PER_DAY = numReadingsPerHour * 24;
+
+    const numDays = Math.round(stats.numReadings/READINGS_PER_DAY);
 
     const totalObj = {
         title: "Total",
         main: formatWithMM(stats.total),
-        subtitle: `${filteredData.length.toLocaleString()} readings over ${ Math.round(filteredData.length/READINGS_PER_DAY) } days`
+        subtitle: `${stats.numReadings.toLocaleString()} readings over ${ numDays } day${ numDays === 1 ? "" : "s"}`
     }
 
-    const numAtMax = filteredData.filter(record => parseFloat(record.reading) === stats.max).length;
-    const maxDate = filteredData.find(record => parseFloat(record.reading) === stats.max);
     const maxObj = {
         title: "High",
-        main: formatWithMM(stats.max),
-        subtitle: numAtMax === 1
-            ? maxDate === undefined ? "" : formatDate(maxDate.timestamp)
-            : createMinMaxSubtitle(numAtMax)
+        main: formatWithMM(stats.max.reading),
+        subtitle: stats.max.count === 1
+            ? stats.max.timestamp === null ? "" : formatDate(stats.max.timestamp)
+            : createMinMaxSubtitle(stats.max.count),
     }
 
-    const numAtMin = filteredData.filter(record => parseFloat(record.reading) === stats.min).length;
-    const minDate = filteredData.find(record => parseFloat(record.reading) === stats.min);
     const minObj = {
         title: "Low",
-        main: formatWithMM(stats.min),
-        subtitle: numAtMin === 1
-            ? minDate === undefined ? "" : formatDate(minDate.timestamp)
-            : createMinMaxSubtitle(numAtMin)
+        main: formatWithMM(stats.min.reading),
+        subtitle: stats.min.count === 1
+            ? stats.min.timestamp === null ? "" : formatDate(stats.min.timestamp)
+            : createMinMaxSubtitle(stats.min.count),
     }
 
     const averageObj = {
         title: "Average",
-        main: filteredData.length === 0 ? formatWithMM(0) : formatWithMM(stats.total / filteredData.length),
+        main: stats.numReadings === 0 ? formatWithMM(0) : formatWithMM(stats.total / stats.numReadings),
         subtitle: "per 15 mins"
     }
 
-    function formatWithMM(num : number){
-        return `${Math.round(num * 100) / 100} mm`;
-    }
-
-    function createMinMaxSubtitle(num : number){
-        return `Occurred ${num.toLocaleString()} times`
-    }
-
     return [totalObj, maxObj, minObj, averageObj];
+}
+
+function formatWithMM(num : number){
+    return `${Math.round(num * 100) / 100} mm`;
+}
+
+function createMinMaxSubtitle(num : number){
+    return `Occurred ${num.toLocaleString()} times`
 }

--- a/raingauge_fe/src/util/dateStringHelpers.ts
+++ b/raingauge_fe/src/util/dateStringHelpers.ts
@@ -29,6 +29,24 @@ export function formatDate(input : Date | string){
     }`;  
 }
 
+export function formatDateForURL(input : Date | string){
+    const date = typeof input == 'string'
+        ? convertStringToDate(input)
+        : input;
+
+    return `${
+        date.getFullYear()
+    }-${
+        formatTwoDigits(date.getMonth()+1)
+    }-${
+        formatTwoDigits(date.getDate())
+    }T${
+        formatTwoDigits(date.getHours())
+    }%3A${
+        formatTwoDigits(date.getMinutes())
+    }`;
+}
+
 export function formatTwoDigits(num : number){
     return num.toString().padStart(2, '0');
 }

--- a/raingauge_fe/src/util/getGraphTitle.ts
+++ b/raingauge_fe/src/util/getGraphTitle.ts
@@ -1,20 +1,17 @@
 /* 
-    Generate a title for the graph, showing the timestamps of the first and last data point in the selected time range
-    (e.g. Suppose the user picked an end time of "23:59". Readings are at 15 min intervals, so the last data points 
-    would be at 23:45, therefore "23:45" is displayed)
+    Generate a title for the graph
 */
 
-import { formatDate } from "./dateStringHelpers";
-import { T_RainGaugeReading } from "./useRainGaugeData";
+import { formatDate, strIsValidForDateCreation } from "./dateStringHelpers";
 
-export function getTimeRangeGraphTitle(selectedData : T_RainGaugeReading[]){
-    selectedData = selectedData === null || selectedData === undefined || !Array.isArray(selectedData) || selectedData.length === 0
-        ? [{ reading: '0', timestamp: "01/01/1900T00:00" }]
-        : selectedData;
 
-    const startStr = formatDate(selectedData[0].timestamp);
-    const endStr = formatDate(selectedData[selectedData.length - 1].timestamp);
-
-    // Plotly has no support for title word wrapping and requires users to pass in their own "<br>" tags
-    return `Data from ${startStr}<br>to ${endStr}`;
+export function getTimeRangeGraphTitle(startDateStr : string, endDateStr : string){
+    if(strIsValidForDateCreation(startDateStr) && strIsValidForDateCreation(endDateStr)){
+        const startStr = formatDate(startDateStr);
+        const endStr = formatDate(endDateStr);
+    
+        // Plotly has no support for title word wrapping and requires users to pass in their own "<br>" tags
+        return `Data from ${startStr}<br>to ${endStr}`;
+    }
+    return "Data error";
 }

--- a/raingauge_fe/src/util/sortRainGaugeData.ts
+++ b/raingauge_fe/src/util/sortRainGaugeData.ts
@@ -1,9 +1,9 @@
-import { T_RainGaugeReading } from "./useRainGaugeData";
+import { T_RainGaugeSubtotal } from "./useRainGaugeData";
 
-export function sortInDateOrder(data : T_RainGaugeReading[]){
-    return data.toSorted((a : T_RainGaugeReading, b : T_RainGaugeReading) => {
-        const aDate = new Date(a.timestamp).valueOf();
-        const bDate = new Date(b.timestamp).valueOf();
+export function sortSubtotalsInDateOrder(data : T_RainGaugeSubtotal[]){
+    return data.toSorted((a : T_RainGaugeSubtotal, b : T_RainGaugeSubtotal) => {
+        const aDate = new Date(a.lastTimestamp).valueOf();
+        const bDate = new Date(b.lastTimestamp).valueOf();
         return aDate - bDate;
     })
 }

--- a/raingauge_fe/src/util/splitIntoCoords.ts
+++ b/raingauge_fe/src/util/splitIntoCoords.ts
@@ -1,17 +1,17 @@
 /*
-    Takes an array of rain gauge readings and splits it into separate arrays of 
-    timestamp and reading, for use in a Plotly graph
+    Takes an array of rain gauge subtotals and splits it into separate arrays of 
+    timestamps and reading, for use in a Plotly graph
 */
 
-import { T_RainGaugeReading } from "./useRainGaugeData";
+import { T_RainGaugeSubtotal } from "./useRainGaugeData";
 
-export function splitIntoCoords(data : T_RainGaugeReading[]){
+export function splitSubtotalIntoCoords(data : T_RainGaugeSubtotal[]){
     let xCoords = ["01/01/1900T00:00"];
     let yCoords = [0];
 
     if(data !== undefined && data !== null && data.length !== 0){
-        xCoords = data.map((record : T_RainGaugeReading) => record.timestamp);
-        yCoords = data.map((record : T_RainGaugeReading) => parseFloat(record.reading));
+        xCoords = data.map((record : T_RainGaugeSubtotal) => record.lastTimestamp);
+        yCoords = data.map((record : T_RainGaugeSubtotal) => parseFloat(record.total));
     }
     return {
         xCoords,


### PR DESCRIPTION
Backend responses are now limited to a maximum of 1k records.

The BE gets the date range from the GET parameters, filters the data, works out the minimum supported subtotal size that would fit within the limit, then condenses the data accordingly.

Changing the date range sometimes fetches fresh data, since a smaller date range may permit smaller subtotal groupings, offering more granularity.

The "sizes in hours" for the subtotals are limited to a handful of options to help with caching the data.

To support the stats cards, subtotals also store some useful details that would otherwise be destroyed: start and end timestamps, details about the min and max in each subtotal, and the number of individual records it represents.

Also:
* Fixed issue with Plotly margins being too wide on mobile
* Removed use of useSWR's "isLoading" because it was causing a reload on every fetch
* To keep things DRY, the backend response now declares the number of records per hour
* Backend response now includes the min and max dates since the response data is no longer guaranteed to cover the entire available time range