### PR TITLE
Add: Table for wettest and driest time periods

### DIFF
--- a/raingauge_be/rainGauge/views.py
+++ b/raingauge_be/rainGauge/views.py
@@ -7,23 +7,26 @@ from rainGauge.util import get_date_from_get_arg
 def api(request):
     if request.method == 'GET':
 
+        # Prep info about all available data and get the config
         query_set = RainGaugeReading.objects.all()
         sorted = query_set.order_by('timestamp')
         minDate = sorted[0].timestamp
         maxDate = sorted[len(sorted) - 1].timestamp
+        config = get_subtotal_config()
 
+        # Obtain dates for the date range (from the GET params, if possible)
         start_arg = request.GET.get('start', None)
         end_arg = request.GET.get('end', None)
+
         start = get_date_from_get_arg(start_arg)
         end = get_date_from_get_arg(end_arg)
-
         if start == None or end_arg == None:
             start = minDate if start == None else start
-            end = sorted[len(sorted) - 1].timestamp if end == None else end
+            end = maxDate if end == None else end
         
+        # Filter to the date range, then convert to subtotals so we're not handing out too much data
         filtered = query_set.filter(timestamp__gte=start, timestamp__lte=end)
         subtotals = get_subtotals(filtered)
-        config = get_subtotal_config()
 
         return JsonResponse({
            'subtotals': subtotals,

--- a/raingauge_fe/src/app/page.tsx
+++ b/raingauge_fe/src/app/page.tsx
@@ -11,7 +11,9 @@ import { useRainGaugeData } from "@/util/useRainGaugeData";
 import { useAdjustableDateRange } from "@/util/useAdjustableDateRange";
 import { splitSubtotalIntoCoords } from "@/util/splitIntoCoords";
 import { getTimeRangeGraphTitle } from "@/util/getGraphTitle";
-
+import { createStatsData } from "@/util/createStatsData";
+import { StatsTable } from "@/components/statsTable/StatsTable";
+import { createWettestDriestTableStats } from "@/util/createTableStats";
 
 export default function Home() {
   const rainData = useRainGaugeData();
@@ -25,6 +27,10 @@ export default function Home() {
 
   const graphCoords = splitSubtotalIntoCoords(dataInDateRange.subtotals);
   const graphTitle = getTimeRangeGraphTitle(dataInDateRange?.subtotals[0]?.firstTimestamp, dataInDateRange?.subtotals[dataInDateRange.subtotals.length - 1]?.lastTimestamp);
+  
+  const recordsPerHour = rainData.data === undefined ? 0 : parseInt(rainData.data.recordsPerHour);
+  const statsData = createStatsData(dataInDateRange.subtotals, recordsPerHour);
+  const tableData = createWettestDriestTableStats(dataInDateRange.subtotals, recordsPerHour);
 
   return (
       <main>
@@ -44,15 +50,19 @@ export default function Home() {
 
           <div className="row mt-5">
             <StatsCards 
-              data = { dataInDateRange.subtotals }
-              numRecordsPerHour = { rainData.data === undefined ? 0 : rainData.data.recordsPerHour }
+              statsData = { statsData }
             />
           </div>
   
           <div className="row mt-5">
+
+            <StatsTable
+              tableData = { tableData }
+            />
             <MapPanel
               data = { rainData }
             />
+
           </div>
         </div>
       </main>

--- a/raingauge_fe/src/components/graphForm/GraphForm.tsx
+++ b/raingauge_fe/src/components/graphForm/GraphForm.tsx
@@ -34,7 +34,7 @@ export function GraphForm({
                 <AccordionItemWrapper
                     accordionID = { accordionID }
                     isOpenOnLoad = { true }
-                    title = { "Show One Month" }
+                    title = { "Pick One Month" }
                     sectionID = { collapseOneMonthID }
                 >
                     <OneMonthForm
@@ -47,7 +47,7 @@ export function GraphForm({
                 <AccordionItemWrapper
                     accordionID = { accordionID }
                     isOpenOnLoad = { false }
-                    title = { "Date & Duration" }
+                    title = { "Set Date & Duration" }
                     sectionID = { collapseDateAndDurationID }
                 >
                     <DateAndDurationForm

--- a/raingauge_fe/src/components/map/MapPanel.tsx
+++ b/raingauge_fe/src/components/map/MapPanel.tsx
@@ -14,16 +14,16 @@ export function MapPanel({ data } : any){
     ), [])
 
     return (
-        <div className={`col-12 pb-3 mb-4 ${styles.panel}`}>
+        <div className={`col-12 col-xl-4 pb-3 mt-5 mt-xl-0 mb-4 ${styles.panel}`}>
             <h2 className="mb-4">Rain Gauge Info</h2>
             <div className="row">
-                <div className="col-12 col-md-6">
+                <div className="col-6 col-xl-12">
                     <Map 
                         position = { [data.lat, data.long] }
                         zoom = { 13 }
                     />
                 </div>
-                <div className="col-12 col-md-6">
+                <div className="col-6 col-xl-12">
                     <dl>
                         <dt>Name</dt>
                         <dl>{ data.gaugeName }</dl>

--- a/raingauge_fe/src/components/statsCards/StatsCards.tsx
+++ b/raingauge_fe/src/components/statsCards/StatsCards.tsx
@@ -1,17 +1,13 @@
 import { StatsCard, T_StatsCardProps } from "./StatsCard";
 
-import { T_RainGaugeSubtotal } from "@/util/useRainGaugeData";
-import { createStatsData } from "./createStatsData";
-
+import { T_StatsDataOutput } from "../../util/createStatsData";
 
 type T_StatsCardsProps = {
-    data : T_RainGaugeSubtotal[],
-    numRecordsPerHour : number,
+    statsData: T_StatsDataOutput
 }
 
-export function StatsCards({ data, numRecordsPerHour } : T_StatsCardsProps){
-    const statsData = createStatsData(data, numRecordsPerHour);
 
+export function StatsCards({ statsData } : T_StatsCardsProps){
     return (
         <>
     { statsData !== null ?

--- a/raingauge_fe/src/components/statsTable/StatsTable.module.scss
+++ b/raingauge_fe/src/components/statsTable/StatsTable.module.scss
@@ -1,0 +1,7 @@
+.tableHead{
+    border-bottom: 1px solid var(--c-panelBorder);
+
+    th{
+        background: var(--c-panelBg);
+    }
+}

--- a/raingauge_fe/src/components/statsTable/StatsTable.tsx
+++ b/raingauge_fe/src/components/statsTable/StatsTable.tsx
@@ -1,0 +1,67 @@
+import styles from './StatsTable.module.scss';
+
+
+type T_StatsTableProps = {
+    tableData : T_StatsTableRowData[]
+}
+
+type T_StatsTableRowData = {
+    heading : string,
+    wettest: T_HydroSuperlativeData,
+    driest: T_HydroSuperlativeData,
+}
+
+type T_HydroSuperlativeData = {
+    description : string,
+    total : number,
+    replaceTotal? : string,
+}
+
+
+export function StatsTable({ tableData } : T_StatsTableProps){
+    return (
+        <div className={"col-12 col-xl-8"}>
+        <table className="table">
+            <thead className={ styles.tableHead }>
+                <tr>
+                    <th scope="col">Time Unit</th>
+                    <th scope="col">Wettest</th>
+                    <th scope="col">Driest</th>
+                </tr>
+            </thead>
+            <tbody>
+            { tableData.map((rowData : T_StatsTableRowData) => {
+                return (
+                    <tr key={ rowData.heading.replaceAll(" ", "") }>
+                        <th scope="row">{ rowData.heading }</th>
+                        <CellForSuperlativeData data = { rowData.wettest } />
+                        <CellForSuperlativeData data = { rowData.driest } />
+                    </tr>
+                )
+            })
+            }
+            </tbody>
+        </table>
+        </div>
+    )
+}
+
+type T_CellForSuperlativeDataProps = {
+    data : T_HydroSuperlativeData,
+}
+
+function CellForSuperlativeData({ data } : T_CellForSuperlativeDataProps){
+    return (
+        <td>
+            <div style={{display: "flex", flexDirection:"column"}}>
+            <strong>{ data.replaceTotal === undefined 
+                ? <>{ `${Math.round(data.total * 100) / 100}` }&nbsp;mm</>
+                : data.replaceTotal
+            }
+            </strong>
+            <span>{ data.description }
+            </span>
+            </div>
+        </td>
+    )
+}

--- a/raingauge_fe/src/util/createTableStats.ts
+++ b/raingauge_fe/src/util/createTableStats.ts
@@ -1,0 +1,345 @@
+import { formatTwoDigits } from "./dateStringHelpers";
+import { T_RainGaugeSubtotal } from "./useRainGaugeData";
+
+type T_WettestDriestResult = {
+    heading : string,
+    wettest : T_SuperlativeResult,
+    driest : T_SuperlativeResult,
+}
+type T_SuperlativeResult = {
+    count : number,
+    total : number,
+    description: string,
+}
+
+type T_Working = {
+    description : string,
+    total : number,
+    numReadings: number,
+}
+
+
+// Obtain an array of information for use in generating a row in a "wettest and driest" table
+export function createWettestDriestTableStats(filteredSortedSubtotals : T_RainGaugeSubtotal[], numReadingsPerHour : number){
+
+    // The duration of the date range affects whether some of this data is meaningful
+    // ("wettest month" is interesting over a year of data, not so much for a week)
+    const durationInHours = getDurationInHoursFromSubtotalData(filteredSortedSubtotals);
+
+    // Configure a "rowdataKit" for each row of the table
+    const hourKit = rowDataKit({
+        heading: "Hour",
+        unitsForDescription: "hour",
+        minReadingsPerUnit: numReadingsPerHour,
+        convertHoursToUnits: (duration : number) => duration,
+        updateResultIn: (subtotal, result, working, minReadingsPerUnit) => updateHourResult({working, subtotal, result, minReadingsPerUnit}),
+        durationInHours
+    });
+
+    const dayKit = rowDataKit({
+        heading: "Day", 
+        unitsForDescription: "day",
+        minReadingsPerUnit: numReadingsPerHour * 24,
+        convertHoursToUnits: (duration : number) => duration / 24,
+        updateResultIn: (subtotal, result, working, minReadingsPerUnit) => updateResult({working, subtotal, result, groupStr: getDayString(new Date(subtotal.firstTimestamp)), minReadingsPerUnit}),
+        durationInHours
+    });
+
+    // If 28 days is good enough to count as a complete month for February, it's good enough to count as a complete month for the rest of the year too
+    const monthKit = rowDataKit({
+        heading: "Month", 
+        unitsForDescription: "month",
+        minReadingsPerUnit: numReadingsPerHour * 24 * 28,
+        convertHoursToUnits: (duration : number) => duration / 24 / 28,
+        updateResultIn: (subtotal, result, working, minReadingsPerUnit) => updateResult({working, subtotal, result, groupStr: getMonthString(new Date(subtotal.firstTimestamp)), minReadingsPerUnit}),
+        durationInHours
+    });
+
+    // Put the kits in an array, in the order they should appear in the table
+    const rowDataKits = [
+        hourKit,
+        dayKit,
+        monthKit,
+    ]
+
+    // Loop through the subtotals once, updating each row for each subtotal
+    for(let i = 0; i < filteredSortedSubtotals.length; i++){
+        const subtotal = filteredSortedSubtotals[i];
+        rowDataKits.forEach(kit => kit.update(subtotal));
+    }
+    rowDataKits.forEach(kit => kit.finalise());
+
+    // Return the final results
+    return rowDataKits.map(kit => kit.getResult());
+}
+
+
+// Collection of useful functions to manage finding the wettest and driest $UNIT of time within a time range
+type T_RowDataKitProps = {
+    convertHoursToUnits : (duration : number) => number, 
+    durationInHours : number,
+    heading : string, 
+    minReadingsPerUnit : number,
+    unitsForDescription : string, 
+    updateResultIn: (subtotal : T_RainGaugeSubtotal, result : T_WettestDriestResult, working : T_Working, minReadingsPerUnit : number) => void, 
+}
+
+function rowDataKit({
+    convertHoursToUnits, durationInHours, heading, minReadingsPerUnit, unitsForDescription, updateResultIn, 
+    } : T_RowDataKitProps){
+
+    // Reasoning: for "wettest" and "driest" to be meaningful, the date range should cover
+    // at least 3 complete $UNITs. This might go a bit wrong if the user sets a custom time range 
+    // that starts and ends in the middle of a $UNIT, but in that case they know what they're doing.
+    const MIN_UNITS_FOR_COMPARISON = 3;
+    // -------------------------------------------------------------------------------------------
+    const isApplicable = convertHoursToUnits(durationInHours) >= MIN_UNITS_FOR_COMPARISON;
+
+    let result = createResultObj(heading, isApplicable);
+    let working = isApplicable
+        ? { description: "", total: 0, numReadings: 0 }
+        : null;
+
+    function update(subtotal : T_RainGaugeSubtotal){
+        if(isApplicable && working !== null){
+            updateResultIn(subtotal, result, working, minReadingsPerUnit);
+        }
+    }
+
+    function finalise(){
+        if(isApplicable && working !== null){
+            // If there's some straggler data in working, add that to the results
+            if(working.description !== ""){
+                updateWettestAndDriest(working, result, minReadingsPerUnit);
+            }
+
+            // If there's a tie for wettest or driest, the description should describe the tie, instead of showing a group string
+            if(result.wettest.description === ""){
+                result.wettest.description = getDescriptionForMoreThanOneResult(result.wettest.count, unitsForDescription);
+            }
+            if(result.driest.description === ""){
+                result.driest.description = getDescriptionForMoreThanOneResult(result.driest.count, unitsForDescription);
+            }
+        }
+    }
+
+    function getResult(){
+        return result;
+    }
+
+    return {
+        update, 
+        finalise,
+        getResult,
+    }
+}
+
+
+// Results object helpers
+function createResultObj(heading : string, isApplicable : boolean) : T_WettestDriestResult{
+    return {
+        heading,
+        wettest: isApplicable ? createSuperlativeObj(-Infinity) : createNASuperlativeObj(),
+        driest: isApplicable ? createSuperlativeObj(Infinity) : createNASuperlativeObj(),
+    };
+
+    function createSuperlativeObj(initTotal : number) : T_SuperlativeResult{
+        return {
+            count: 0,
+            total: initTotal,
+            description: ""
+        }
+    }
+
+    function createNASuperlativeObj(){
+        return {
+            count: 0,
+            total: 0,
+            replaceTotal: "N/A",
+            description: "Date range is too small"
+        }
+    }
+}
+
+
+// Update functions
+type T_UpdateResultProps = {
+    groupStr : string,
+    minReadingsPerUnit : number,
+    result : T_WettestDriestResult, 
+    subtotal : T_RainGaugeSubtotal, 
+    working : T_Working, 
+}
+
+function updateResult({ working, subtotal, result, groupStr, minReadingsPerUnit} : T_UpdateResultProps){
+    // If this record belongs in a new group, first handle the old group: run the min/max comparison, update the results, then reset working
+    if(working.description !== "" && groupStr !== working.description) {
+        updateWettestAndDriest(working, result, minReadingsPerUnit,);
+        working.description = "";
+        working.total = 0;
+        working.numReadings = 0;
+    }
+
+    // Handle this record
+    if(groupStr === working.description){
+        working.total = working.total + parseFloat(subtotal.total);
+        working.numReadings = working.numReadings + parseInt(subtotal.numReadings);
+    }
+    else if(working.description === ""){
+        working.description = groupStr;
+        working.total = parseFloat(subtotal.total);
+        working.numReadings = parseInt(subtotal.numReadings);
+    } 
+}
+
+
+function updateWettestAndDriest(working : T_Working, result : T_WettestDriestResult, minReadingsPerUnit : number){
+    if(working.numReadings >= minReadingsPerUnit){
+        result.wettest = getUpdatedMinMaxObject(result.wettest, working.total, working.description, working.total > result.wettest.total);
+        result.driest = getUpdatedMinMaxObject(result.driest, working.total, working.description, working.total < result.driest.total); 
+    }
+}
+
+function getUpdatedMinMaxObject(result : T_SuperlativeResult, total : number, description : string, wantReplace : boolean){
+    let updatedCount : number;
+    let updatedTotal : number;
+    let updatedDescription: string;
+
+    if(wantReplace){
+        updatedCount = 1;
+        updatedTotal = total;
+        updatedDescription = description;
+    }
+    else if(total == result.total){
+        updatedCount = result.count + 1;
+        updatedTotal = total;
+        updatedDescription = "";
+    }
+    else{
+        updatedCount = result.count;
+        updatedTotal = result.total;
+        updatedDescription = result.description;
+    }
+
+    return {
+        count: updatedCount,
+        total: updatedTotal,
+        description: updatedDescription
+    }
+}
+
+
+/*  SPECIAL HOUR HELPERS
+    When the date range gets too large, the backend stops reporting individual readings and starts reporting
+    grouped subtotals. Many of these subtotals are larger than one hour, so information about individual hours
+    is lost.
+    
+    To get around this, when the subtotal spans more than one hour, the backend keeps track of the max and min
+    hours and adds that info to the subtotal.
+
+    This means that updating the result for hours works a bit differently to day and month, because it needs
+    to also be able to handle the backend's min/max data
+*/
+function updateHourResult({working, subtotal, result, minReadingsPerUnit} : Pick<T_UpdateResultProps, "working" | "subtotal" | "result" | "minReadingsPerUnit" >){
+    if(!updateHourResultForSubtotalsWithMinMaxHourData(subtotal, result, minReadingsPerUnit)){
+        updateResult({working, subtotal, result, groupStr: getHourString(new Date(subtotal.lastTimestamp)), minReadingsPerUnit});
+    }
+}
+
+function updateHourResultForSubtotalsWithMinMaxHourData(subtotal : T_RainGaugeSubtotal, result : T_WettestDriestResult, minReadingsPerUnit : number){
+    if(subtotal.minHour === undefined || subtotal.maxHour === undefined){
+        return false;
+    }
+
+    updateOneHour(subtotal.minHour.count, subtotal.minHour.timestamp, subtotal.minHour.reading, subtotal.numReadings, result);
+    updateOneHour(subtotal.maxHour.count, subtotal.maxHour.timestamp, subtotal.maxHour.reading, subtotal.numReadings, result);
+    return true;
+
+    function updateOneHour(count : string, timestamp : string, reading : string, numReadings : string, result : T_WettestDriestResult){
+        const desc = parseInt(count) === 0
+            ? ""
+            : getHourString(new Date(timestamp));
+
+        let dummyWorking = {
+            count: 0,
+            numReadings: parseInt(numReadings),
+            description: desc,
+            total: parseInt(reading),
+        }
+        updateWettestAndDriest(dummyWorking, result, minReadingsPerUnit);
+    }  
+}
+
+
+
+// Group strings
+function getHourString(endDate : Date){
+    /*
+        Note/example: readings at 06:15, 06:30, 06:45 and 07:00 should be grouped together to 
+        form an hour, since the 07:00 reading covers rain that fell in the preceeding 15 mins. 
+    */
+
+    // Use Date object so the built in stuff can handle days, months and years flipping over
+    let displayStart = new Date(endDate.getTime());
+    let displayEnd = new Date(endDate.getTime());
+
+    // Handle hours ticking over
+    if(endDate.getMinutes() === 0){
+        displayStart.setMinutes(-1);
+    } else {
+        displayEnd.setHours(endDate.getHours() + 1);
+    }
+
+    const dayStr = getDayString(displayStart);
+    return `${formatTwoDigits(displayStart.getHours())}:01 - ${formatTwoDigits(displayEnd.getHours())}:00, ${dayStr}`;
+
+}
+    
+function getDayString(date : Date){
+    if(date.getMinutes() === 0 && date.getHours() === 0){
+        // This could be the "01 MONTH YEAR 00:00" reading, which
+        // needs to be counted in the last day of the previous month, which could also tick back the year
+        date.setMinutes(-15);
+    }
+    return `${date.getDate()} ${date.toLocaleString('default', { month: 'short' })} ${date.getFullYear()}`;
+}
+
+
+function getMonthString(date : Date){
+    let dayToUse = new Date(date.getFullYear(), date.getMonth(), 1);
+    if(date.getHours() === 0 && date.getMinutes() === 0){
+        // This could be the "01 MONTH YEAR 00:00" reading, which
+        // needs to be counted in month - 1, which could also tick back the year
+        dayToUse.setMinutes(-10);
+    }
+    return `${dayToUse.toLocaleString('default', { month: 'long' })} ${ dayToUse.getFullYear() }`
+}
+
+
+
+// Simple helpers
+function getDurationInHoursFromSubtotalData(filteredSortedSubtotals : T_RainGaugeSubtotal[]){
+    if(filteredSortedSubtotals === undefined || filteredSortedSubtotals.length === 0){
+        return 0;
+    }
+
+    const startTimestampStr = filteredSortedSubtotals[0].firstTimestamp;
+    const endTimestampStr = filteredSortedSubtotals[filteredSortedSubtotals.length - 1].lastTimestamp;
+
+    try{
+        const start = new Date(startTimestampStr);
+        const end = new Date(endTimestampStr);
+
+        const diffInMs = end.getTime() - start.getTime();
+        return diffInMs / 1000 / 60 / 60;
+    }
+    catch{
+        return 0;
+    }
+}
+
+
+function getDescriptionForMoreThanOneResult(count : number, unitStr : string){
+    return `${ count } separate ${ unitStr }s`;
+}
+

--- a/raingauge_fe/src/util/getGraphTitle.ts
+++ b/raingauge_fe/src/util/getGraphTitle.ts
@@ -11,7 +11,7 @@ export function getTimeRangeGraphTitle(startDateStr : string, endDateStr : strin
         const endStr = formatDate(endDateStr);
     
         // Plotly has no support for title word wrapping and requires users to pass in their own "<br>" tags
-        return `Data from ${startStr}<br>to ${endStr}`;
+        return `Readings from ${startStr}<br>to ${endStr}`;
     }
-    return "Data error";
+    return "...";
 }

--- a/raingauge_fe/src/util/useRainGaugeData.ts
+++ b/raingauge_fe/src/util/useRainGaugeData.ts
@@ -27,6 +27,8 @@ export type T_RainGaugeSubtotal = {
     numReadings : string,
     max : T_RainGaugeSubtotalMinMax,
     min : T_RainGaugeSubtotalMinMax,
+    minHour? : T_RainGaugeSubtotalMinMax,
+    maxHour? : T_RainGaugeSubtotalMinMax,
 }
 
 export type T_RainGaugeSubtotalMinMax = {


### PR DESCRIPTION
Added a table to display the wettest and driest hour, day and month in the selected time range.

To support this:
* Backend now identifies the min and max hour in each subtotal, as well as the min and max reading (otherwise "wettest/driest hour" would be impossible for the frontend to determine on larger date ranges)
* Also got backend to output some config details, for use in stats
* Adjusted Bootstrap classes on Map to fit around the table

Also:
* Adjusted collapsable form headings to be more specific about what they contain
* Moved the call to calculate stats for the cards out of the component and into page, decoupling the display from the logic
* Fiddled with the graph title (I got tired of it claiming there was an error every time it fetched new data)