### PR TITLE
Fix: Stats cards flickering / reset data broken

### DIFF
--- a/raingauge_fe/src/components/graphWithForm/GraphWithForm.tsx
+++ b/raingauge_fe/src/components/graphWithForm/GraphWithForm.tsx
@@ -16,7 +16,7 @@ type T_GraphWithFormProps = {
 
 export function GraphWithForm({ title, xCoords, yCoords, formKit } : T_GraphWithFormProps){
     return (
-        <div className="row mt-3">
+        <div className="row mt-3 align-items-start">
             <div className="col-12 col-md-5 col-lg-4 col-xl-3 order-2 order-md-1">
                 <GraphForm
                     customFormKit = { formKit.customDateRange }

--- a/raingauge_fe/src/components/graphWithForm/graphForm/dateAndDurationForm/useDateAndDurationForm.ts
+++ b/raingauge_fe/src/components/graphWithForm/graphForm/dateAndDurationForm/useDateAndDurationForm.ts
@@ -38,15 +38,16 @@ export function useDateAndDurationForm({
     const [selectedDuration, setSelectedDuration] = useState<string>("toEnd");
     const [formError, setFormError] = useState<string | null>(null);
     const [formWarning, setFormWarning] = useState<string | null>(null);
+    const [lockUpdate, setLockUpdate] = useState<boolean>(false);
 
+    // useEffect to auto-update the date range when the user picks a date or changes the duration
     useEffect(() => {
-        if(startDateStr === "" && minDate !== ""){
-            setStartDateStr(minDate.slice(0, -9));
+        if(lockUpdate){
+            setLockUpdate(false);
         }
-    }, [minDate]);
-
-    useEffect(() => {
-        updateGraphData();
+        else{
+            updateGraphData();
+        }
     }, [startDateStr, selectedDuration])
 
     const CRITICAL_ERROR_MESSAGE = "Date and Duration has stopped working. Please use another method of selecting a date range. Sorry for the inconvenience.";
@@ -71,7 +72,8 @@ export function useDateAndDurationForm({
     }
 
     function onReset(){
-        setStartDateStr(minDate.slice(0, -9));
+        setLockUpdate(true);
+        setStartDateStr("");
         setSelectedDuration("toEnd");
         resetErrorAndWarning();
     }


### PR DESCRIPTION
Bug #1:
On loading the page, the stats cards flickered and changed some of the stats.

Cause:
Date and duration form.
The flickering was caused by it initialising its date to the minimum, which counted as a change, which caused it to auto-update the date range, which altered it because date and duration chops "straggler" data off the ends of the range.

Factors to consider:
If the form initialises to "00:01", to capture a full day, it changes the date range and so makes the stats flicker.

If the form invisibly initialises to "00:00" (to prevent flicker) then it will give different results for the first day depending on if the user uses it as it loads ("00:00"), or changes it to that date ("00:01")

Solution:
* Removed the automatic initialisation to the start date. It makes the date selection a bit more annoying, but avoids flicker and makes it behave consistently

----

Bug #2:
On resetting the data, the whole page crashed.

Cause:
Date and duration form.
The reset was also auto-triggering a date range change, which clashed with the "main" reset, causing it to get its fetches in a twist and fall on its face.

Solution:
Added a lock to prevent the auto-update when called by onReset()